### PR TITLE
Rewrite Typechecking to tag ASTs

### DIFF
--- a/src/ast/parser.rs
+++ b/src/ast/parser.rs
@@ -1,4 +1,4 @@
-use super::{Exp, posed_exp, _Exp};
+use super::{AST, posed_exp, Exp};
 use super::position::{Pos};
 use lalrpop_util::lalrpop_mod;
 
@@ -10,9 +10,9 @@ pub enum ParseError {
     UnexpectedToken(Pos),
 }
 
-pub fn parse(source : String) -> Result<Exp, ParseError> {
+pub fn parse(source : String) -> Result<AST, ParseError> {
     let str_src: &str = &*source;
-    let box_exp = posed_exp(_Exp::Unit, 1, 1);
+    let box_exp = posed_exp(Exp::Unit, 1, 1);
 
      Ok(*box_exp)
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,16 +26,8 @@ use typecheck::{initial_type_env, initial_value_env, type_exp, TigerType, R};
 //extern crate lalrpop_util;
 extern crate pathfinding;
 
-fn possed_exp(exp: _Exp) -> Exp {
-    Exp {node: exp, pos: Pos {line: 0, column: 0}}
-}
-
-fn boxed_exp(exp: _Exp) -> Box<Exp> {
-    Box::new(Exp {node: exp, pos: Pos {line: 0, column: 0}})
-}
-
 fn main() {
-    let exp = possed_exp(_Exp::Let {
+    let exp = make_ast(Exp::Let {
         decs: vec![
             Dec::TypeDec(vec![(
                 _TypeDec::new(
@@ -59,19 +51,19 @@ fn main() {
                 _VarDec::new(
                     Symbol::from("foo"),
                     Some(Symbol::from("List")),
-                    boxed_exp(_Exp::Record {
+                    boxed_ast(Exp::Record {
                         fields: vec![
-                            (Symbol::from("head"), boxed_exp(_Exp::Int(1))),
-                            (Symbol::from("tail"), boxed_exp(_Exp::Record {
+                            (Symbol::from("head"), boxed_ast(Exp::Int(1))),
+                            (Symbol::from("tail"), boxed_ast(Exp::Record {
                                 fields: vec![
-                                    (Symbol::from("head"), boxed_exp(_Exp::Int(2))),
-                                    (Symbol::from("tail"), boxed_exp(_Exp::Record {
+                                    (Symbol::from("head"), boxed_ast(Exp::Int(2))),
+                                    (Symbol::from("tail"), boxed_ast(Exp::Record {
                                         fields: vec![
-                                            (Symbol::from("head"), boxed_exp(_Exp::Int(3))),
-                                            (Symbol::from("tail"), boxed_exp(_Exp::Record {
+                                            (Symbol::from("head"), boxed_ast(Exp::Int(3))),
+                                            (Symbol::from("tail"), boxed_ast(Exp::Record {
                                                 fields: vec![
-                                                    (Symbol::from("head"), boxed_exp(_Exp::Int(4))),
-                                                    (Symbol::from("tail"), boxed_exp(_Exp::Nil))
+                                                    (Symbol::from("head"), boxed_ast(Exp::Int(4))),
+                                                    (Symbol::from("tail"), boxed_ast(Exp::Nil))
                                                 ],
                                                 typ: Symbol::from("List"),
                                             }))
@@ -87,19 +79,19 @@ fn main() {
                 ),
                 Pos{line: 0, column: 2}
             )],
-        body: boxed_exp(_Exp::Var(
-            Var::Field(
-                Box::new(Var::Simple(Symbol::from("foo"))),
+        body: boxed_ast(Exp::Var(
+            make_var(VarKind::Field(
+                boxed_var(VarKind::Simple(Symbol::from("foo"))),
                 Symbol::from("head")
-            )
+            ))
         ))
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(exp, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }

--- a/src/parser.lalrpop
+++ b/src/parser.lalrpop
@@ -3,32 +3,32 @@ use crate::ast::tigerabs::*;
 
 grammar;
 
-pub Expr: Box<Exp> = {
-    <l: Expr> "|" <r: CompExp> => {
-        let no_pos_exp = _Exp::If {
+pub ASTr: Box<AST> = {
+    <l: ASTr> "|" <r: CompAST> => {
+        let no_pos_exp = Exp::If {
             test: l,
-            then_: posed_exp(_Exp::Int(1), 0, 0),
+            then_: posed_exp(Exp::Int(1), 0, 0),
             else_: Some(r),
         };
         return posed_exp(no_pos_exp, 0, 0)
     },
-    <l: Expr> "&" <r: CompExp> => {
-        let no_pos_exp = _Exp::If {
+    <l: ASTr> "&" <r: CompAST> => {
+        let no_pos_exp = Exp::If {
             test: l,
             then_: r,
-            else_: Some(posed_exp(_Exp::Int(0), 0, 0)),
+            else_: Some(posed_exp(Exp::Int(0), 0, 0)),
         };
         return posed_exp(no_pos_exp, 0, 0)
     },
-    CompExp,
+    CompAST,
 }
 
-pub CompExp: Box<Exp> = {
-    <l:AddExp> <o:CompOp> <r:AddExp> => {
-        let no_pos_exp = _Exp::Op {left: l, oper: o, right: r};
+pub CompAST: Box<AST> = {
+    <l:AddAST> <o:CompOp> <r:AddAST> => {
+        let no_pos_exp = Exp::Op {left: l, oper: o, right: r};
         return posed_exp(no_pos_exp, 0, 0)
     },
-    AddExp,
+    AddAST,
 }
 
 CompOp: Oper = {
@@ -40,12 +40,12 @@ CompOp: Oper = {
     "<>" => Oper::NeqOp,
 }
 
-AddExp: Box<Exp> = {
-    <l:AddExp> <o:AddOp> <r:MultExp> => {
-        let no_pos_exp = _Exp::Op {left: l, oper: o, right: r};
+AddAST: Box<AST> = {
+    <l:AddAST> <o:AddOp> <r:MultAST> => {
+        let no_pos_exp = Exp::Op {left: l, oper: o, right: r};
         return posed_exp(no_pos_exp, 0, 0)
     },
-    MultExp,
+    MultAST,
 }
 
 AddOp: Oper = {
@@ -53,9 +53,9 @@ AddOp: Oper = {
     "-" => Oper::MinusOp,
 };
 
-MultExp: Box<Exp> = {
-    <l:MultExp> <o:MultOp> <r:Term> => {
-        let no_pos_exp = _Exp::Op {left: l, oper: o, right: r};
+MultAST: Box<AST> = {
+    <l:MultAST> <o:MultOp> <r:Term> => {
+        let no_pos_exp = Exp::Op {left: l, oper: o, right: r};
         return posed_exp(no_pos_exp, 0, 0)
     },
     Term,
@@ -66,12 +66,12 @@ MultOp: Oper = {
     "/" => Oper::DivideOp,
 };
 
-Term: Box<Exp> = {
+Term: Box<AST> = {
     Num => {
-        let no_pos_exp = _Exp::Int(<>);
+        let no_pos_exp = Exp::Int(<>);
         return posed_exp(no_pos_exp, 0, 0)
     },
-    "(" <Expr> ")",
+    "(" <ASTr> ")",
 };
 
 Num: i32 = {

--- a/src/test/escape.rs
+++ b/src/test/escape.rs
@@ -1,20 +1,10 @@
-use super::super::ast::*;
-use super::super::ast::position::*;
-use super::super::tree::escape::*;
-
-
-fn possed_exp(exp: _Exp) -> Exp {
-    Exp {node: exp, pos: Pos {line: 0, column: 0}}
-}
-
-fn boxed_exp(exp: _Exp) -> Box<Exp> {
-    Box::new(Exp {node: exp, pos: Pos {line: 0, column: 0}})
-}
-
+use crate::ast::*;
+use crate::ast::position::*;
+use crate::tree::escape::*;
 
 #[test]
 fn escaped_arguments() {
-    let exp = possed_exp(_Exp::Let {
+    let exp = make_ast(Exp::Let {
         decs: vec![
             Dec::FunctionDec(vec![(
                 _FunctionDec::new(
@@ -25,7 +15,7 @@ fn escaped_arguments() {
                         escape: false,
                     }],
                     Some(Symbol::from("int")),
-                    boxed_exp(_Exp::Let {
+                    boxed_ast(Exp::Let {
                         decs: vec![
                             Dec::FunctionDec(vec![(
                                 _FunctionDec::new(
@@ -36,30 +26,30 @@ fn escaped_arguments() {
                                         escape: false,
                                     }],
                                     Some(Symbol::from("int")),
-                                    boxed_exp(_Exp::Op {
-                                        left: boxed_exp(_Exp::Var(Var::Simple(Symbol::from("arg1")))),
-                                        right: boxed_exp(_Exp::Var(Var::Simple(Symbol::from("arg2")))),
+                                    boxed_ast(Exp::Op {
+                                        left: boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("arg1"))))),
+                                        right: boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("arg2"))))),
                                         oper: Oper::PlusOp
                                     }),
                                 ),
                                 Pos{line: 0, column: 0}
                             )]),
                         ],
-                        body: boxed_exp(_Exp::Call {
+                        body: boxed_ast(Exp::Call {
                             func: Symbol::from("baaz"),
-                            args: vec![possed_exp(_Exp::Int(2))]
+                            args: vec![make_ast(Exp::Int(2))]
                         })
                     }),
                 ),
                 Pos{line: 0, column: 0}
             )]),
         ],
-        body: boxed_exp(_Exp::Call {
+        body: boxed_ast(Exp::Call {
             func: Symbol::from("fun1"),
-            args: vec![possed_exp(_Exp::Int(2))]
+            args: vec![make_ast(Exp::Int(2))]
         })
     });
-    if let Exp {node: _Exp::Let {decs, ..}, ..} = find_escapes(exp) {
+    if let AST {node: Exp::Let {decs, ..}, ..} = find_escapes(exp) {
         if let Some((Dec::FunctionDec(funs), ..)) = decs.split_first() {
             if let Some(((_FunctionDec{params, ..}, ..), ..)) = funs.split_first() {
                 if let Some((Field {escape, ..}, ..)) = params.split_first() {
@@ -77,7 +67,7 @@ fn escaped_arguments() {
 
 #[test]
 fn not_escaped_arguments() {
-    let exp = possed_exp(_Exp::Let {
+    let exp = make_ast(Exp::Let {
         decs: vec![
             Dec::FunctionDec(vec![(
                 _FunctionDec::new(
@@ -88,7 +78,7 @@ fn not_escaped_arguments() {
                         escape: false,
                     }],
                     Some(Symbol::from("int")),
-                    boxed_exp(_Exp::Let {
+                    boxed_ast(Exp::Let {
                         decs: vec![
                             Dec::FunctionDec(vec![(
                                 _FunctionDec::new(
@@ -99,30 +89,30 @@ fn not_escaped_arguments() {
                                         escape: false,
                                     }],
                                     Some(Symbol::from("int")),
-                                    boxed_exp(_Exp::Op {
-                                        left: boxed_exp(_Exp::Var(Var::Simple(Symbol::from("arg2")))),
-                                        right: boxed_exp(_Exp::Var(Var::Simple(Symbol::from("arg2")))),
+                                    boxed_ast(Exp::Op {
+                                        left: boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("arg2"))))),
+                                        right: boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("arg2"))))),
                                         oper: Oper::PlusOp
                                     }),
                                 ),
                                 Pos{line: 0, column: 0}
                             )]),
                         ],
-                        body: boxed_exp(_Exp::Call {
+                        body: boxed_ast(Exp::Call {
                             func: Symbol::from("baaz"),
-                            args: vec![possed_exp(_Exp::Int(2))]
+                            args: vec![make_ast(Exp::Int(2))]
                         })
                     }),
                 ),
                 Pos{line: 0, column: 0}
             )]),
         ],
-        body: boxed_exp(_Exp::Call {
+        body: boxed_ast(Exp::Call {
             func: Symbol::from("fun1"),
-            args: vec![possed_exp(_Exp::Int(2))]
+            args: vec![make_ast(Exp::Int(2))]
         })
     });
-    if let Exp {node: _Exp::Let {decs, ..}, ..} = find_escapes(exp) {
+    if let AST {node: Exp::Let {decs, ..}, ..} = find_escapes(exp) {
         if let Some((Dec::FunctionDec(funs), ..)) = decs.split_first() {
             if let Some(((_FunctionDec{params, ..}, ..), ..)) = funs.split_first() {
                 if let Some((Field {escape, ..}, ..)) = params.split_first() {
@@ -140,10 +130,10 @@ fn not_escaped_arguments() {
 
 #[test]
 fn escaped_var() {
-    let exp = possed_exp(_Exp::Let {
+    let exp = make_ast(Exp::Let {
         decs: vec![
             Dec::VarDec(
-                _VarDec{name: Symbol::from("var1"), escape: false, init: boxed_exp(_Exp::Int(1)), typ: None}, // var defined here
+                _VarDec{name: Symbol::from("var1"), escape: false, init: boxed_ast(Exp::Int(1)), typ: None}, // var defined here
                 Pos{line: 0, column: 0}
             ),
             Dec::FunctionDec(vec![(
@@ -155,17 +145,17 @@ fn escaped_var() {
                         escape: false,
                     }],
                     Some(Symbol::from("int")),
-                    boxed_exp(_Exp::Var(Var::Simple(Symbol::from("var1")))), // and used here
+                    boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("var1"))))), // and used here
                 ),
                 Pos{line: 0, column: 0}
             )]),
         ],
-        body: boxed_exp(_Exp::Call {
+        body: boxed_ast(Exp::Call {
             func: Symbol::from("fun1"),
-            args: vec![possed_exp(_Exp::Int(2))]
+            args: vec![make_ast(Exp::Int(2))]
         })
     });
-    if let Exp {node: _Exp::Let {decs, ..}, ..} = find_escapes(exp) {
+    if let AST {node: Exp::Let {decs, ..}, ..} = find_escapes(exp) {
         if let Some((Dec::VarDec(_VarDec{escape, ..}, ..), ..)) = decs.split_first() {
             if *escape {
                 return () // PASS
@@ -178,10 +168,10 @@ fn escaped_var() {
 }
 #[test]
 fn not_escaped_var() {
-    let exp = possed_exp(_Exp::Let {
+    let exp = make_ast(Exp::Let {
         decs: vec![
             Dec::VarDec(
-                _VarDec{name: Symbol::from("var1"), escape: false, init: boxed_exp(_Exp::Int(1)), typ: None}, // var defined, never used
+                _VarDec{name: Symbol::from("var1"), escape: false, init: boxed_ast(Exp::Int(1)), typ: None}, // var defined, never used
                 Pos{line: 0, column: 0}
             ),
             Dec::FunctionDec(vec![(
@@ -193,17 +183,17 @@ fn not_escaped_var() {
                         escape: false,
                     }],
                     Some(Symbol::from("int")),
-                    boxed_exp(_Exp::Var(Var::Simple(Symbol::from("arg1")))),  // and used here
+                    boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("arg1"))))),  // and used here
                 ),
                 Pos{line: 0, column: 0}
             )]),
         ],
-        body: boxed_exp(_Exp::Call {
+        body: boxed_ast(Exp::Call {
             func: Symbol::from("fun1"),
-            args: vec![possed_exp(_Exp::Int(2))]
+            args: vec![make_ast(Exp::Int(2))]
         })
     });
-    if let Exp {node: _Exp::Let {decs, ..}, ..} = find_escapes(exp) {
+    if let AST {node: Exp::Let {decs, ..}, ..} = find_escapes(exp) {
         if let Some((Dec::VarDec(_VarDec{escape, ..}, ..), ..)) = decs.split_first() {
             if !*escape {
                 return () // PASS
@@ -218,11 +208,11 @@ fn not_escaped_var() {
 #[test]
 fn escaped_for() {
     // TODO
-    let exp = possed_exp(_Exp::For {
+    let exp = make_ast(Exp::For {
         var: Symbol::from("i"), // iterator defined here
-        lo: boxed_exp(_Exp::Int(1)),
-        hi: boxed_exp(_Exp::Int(1)),
-        body: boxed_exp(_Exp::Let {
+        lo: boxed_ast(Exp::Int(1)),
+        hi: boxed_ast(Exp::Int(1)),
+        body: boxed_ast(Exp::Let {
             decs: vec![
                 Dec::FunctionDec(vec![(
                     _FunctionDec::new(
@@ -233,30 +223,30 @@ fn escaped_for() {
                             escape: false,
                         }],
                         Some(Symbol::from("int")),
-                        boxed_exp(_Exp::Var(Var::Simple(Symbol::from("i")))), // and used here
+                        boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("i"))))), // and used here
                     ),
                     Pos{line: 0, column: 0}
                 )]),
             ],
-            body: boxed_exp(_Exp::Call {
+            body: boxed_ast(Exp::Call {
                 func: Symbol::from("fun1"),
-                args: vec![possed_exp(_Exp::Int(2))]
+                args: vec![make_ast(Exp::Int(2))]
             })
         }),
         escape: false
     });
-    if let Exp {node: _Exp::For {escape, ..}, ..} = find_escapes(exp) {
+    if let AST {node: Exp::For {escape, ..}, ..} = find_escapes(exp) {
         assert!(escape)
     }
 }
 #[test]
 fn not_escaped_for() {
     // TODO
-    let exp = possed_exp(_Exp::For {
+    let exp = make_ast(Exp::For {
         var: Symbol::from("i"), // iterator defined here
-        lo: boxed_exp(_Exp::Int(1)),
-        hi: boxed_exp(_Exp::Int(1)),
-        body: boxed_exp(_Exp::Let {
+        lo: boxed_ast(Exp::Int(1)),
+        hi: boxed_ast(Exp::Int(1)),
+        body: boxed_ast(Exp::Let {
             decs: vec![
                 Dec::FunctionDec(vec![(
                     _FunctionDec::new(
@@ -267,19 +257,19 @@ fn not_escaped_for() {
                             escape: false,
                         }],
                         Some(Symbol::from("int")),
-                        boxed_exp(_Exp::Var(Var::Simple(Symbol::from("arg1")))), // but not used
+                        boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("arg1"))))), // but not used
                     ),
                     Pos{line: 0, column: 0}
                 )]),
             ],
-            body: boxed_exp(_Exp::Call {
+            body: boxed_ast(Exp::Call {
                 func: Symbol::from("fun1"),
-                args: vec![possed_exp(_Exp::Int(2))]
+                args: vec![make_ast(Exp::Int(2))]
             })
         }),
         escape: false
     });
-    if let Exp {node: _Exp::For {escape, ..}, ..} = find_escapes(exp) {
+    if let AST {node: Exp::For {escape, ..}, ..} = find_escapes(exp) {
         assert!(!escape)
     }
 }

--- a/src/test/typechecking.rs
+++ b/src/test/typechecking.rs
@@ -14,13 +14,13 @@ fn good() {
     for direntry in source_files {
         let path = direntry.expect("direntry").path();
         let contents = read_to_string(&path).expect("read_to_string");
-        let exp = parse(contents).expect("parser error");
+        let ast =  parse(contents).expect("parser error");
         let type_env = TypeEnviroment::new();
         let value_env = ValueEnviroment::new();
-        let res = type_exp(&exp , &type_env, &value_env);
+        let res = type_exp(ast.clone() , &type_env, &value_env);
         match res {
             Ok(..) => (),
-            Err(type_error) => panic!("Expresion: {:?}\n Type Error: {:?}", exp, type_error)
+            Err(type_error) => panic!("ASTresion: {:?}\n Type Error: {:?}", ast, type_error)
         }
     }
 }
@@ -32,56 +32,44 @@ fn bad_type() {
     for direntry in source_files {
         let path = direntry.expect("direntry").path();
         let contents = read_to_string(&path).expect("read_to_string");
-        let exp = parse(contents).expect("falla el parser");
+        let ast =  parse(contents).expect("falla el parser");
         let type_env = TypeEnviroment::new();
         let value_env = ValueEnviroment::new();
-        let res = type_exp(&exp , &type_env, &value_env);
+        let res = type_exp(ast.clone() , &type_env, &value_env);
         match res {
             Err(..) => (),
-            Ok(tiger_type) => panic!("Expresion: {:?}\n Type: {:?}", exp, tiger_type),
+            Ok(tiger_type) => panic!("ASTresion: {:?}\n Type: {:?}", ast, tiger_type),
         }
     }
 }
 
-fn possed_exp(exp: _Exp) -> Exp {
-    Exp {node: exp, pos: Pos {line: 0, column: 0}}
+fn make_ast(exp: Exp) -> AST {
+    AST {node: exp, pos: Pos {line: 0, column: 0}, typ: Arc::new(TigerType::Untyped)}
 }
 
 #[test]
 fn unitexp() {
-    let exp = Exp {
-        node: _Exp::Unit,
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast = make_ast(Exp::Unit);
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TUnit => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TUnit => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn nilexp() {
-    let exp = Exp {
-        node: _Exp::Nil,
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast = make_ast(Exp::Nil);
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) => match *tiger_type {
+        Ok(AST{typ, ..}) => match *typ {
             TigerType::TNil => (),
-            _ => panic!("wrong type: {:?}", tiger_type),
+            _ => panic!("wrong type: {:?}", typ),
         },
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
@@ -89,110 +77,80 @@ fn nilexp() {
 
 #[test]
 fn breakexp() {
-    let exp = Exp {node: _Exp::Break, pos: Pos {line: 0, column: 0}};
+    let ast =  make_ast(Exp::Break);
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TUnit => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TUnit => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn intexp() {
-    let exp = Exp {
-        node: _Exp::Int(1),
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast =  make_ast(Exp::Int(1));
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn stringexp() {
-    let exp = Exp {
-        node: _Exp::String(String::from("lorem ipsum")),
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast =  make_ast(Exp::String(String::from("lorem ipsum")));
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TString => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TString => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn varexp_simplevar_ok() {
-    let exp = Exp {
-        node: _Exp::Var(Var::Simple(Symbol::from("foo"))),
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast =  make_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("foo")))));
     let type_env = initial_type_env();
     let mut value_env = initial_value_env();
     value_env.insert(Symbol::from("foo"), EnvEntry::Var{ty: Arc::new(TigerType::TInt(R::RW)),});
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn varexp_simplevar_no_declarada() {
-    let exp = Exp {
-        node: _Exp::Var(Var::Simple(Symbol::from("foo"))),
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast =  make_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("foo")))));
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::UndeclaredSimpleVar(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
-        Ok(tiger_type) => panic!("Should error, returns: {:?}", tiger_type)
+        Ok(ast) => panic!("Should error, returns: {:?}", ast)
     }
 }
 
 #[test]
 fn varexp_simplevar_no_es_simple() {
-    let exp = Exp {
-        node: _Exp::Var(Var::Simple(Symbol::from("f"))),
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast =  make_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("f")))));
     let type_env = initial_type_env();
     let mut value_env = initial_value_env();
     value_env.insert(Symbol::from("f"), EnvEntry::Func {
         formals: vec![],
         result: Arc::new(TigerType::TUnit),
     });
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::NotSimpleVar(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -202,13 +160,11 @@ fn varexp_simplevar_no_es_simple() {
 
 #[test]
 fn varexp_fieldvar_ok() {
-    let exp = Exp {
-        node: _Exp::Var(Var::Field(Box::new(Var::Simple(Symbol::from("foo"))),Symbol::from("bar"))),
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast = make_ast(Exp::Var(
+        make_var(VarKind::Field(
+            boxed_var(VarKind::Simple(Symbol::from("foo"))),
+            Symbol::from("bar")))
+    ));
     let mut type_env = initial_type_env();
     let mut value_env = initial_value_env();
     let field_type = Arc::new(TigerType::TInt(R::RW));
@@ -220,23 +176,21 @@ fn varexp_fieldvar_ok() {
     value_env.insert(Symbol::from("foo"), EnvEntry::Var{
         ty: foo_type,
     });
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn varexp_fieldvar_field_inexistente() {
-    let exp = Exp {
-        node: _Exp::Var(Var::Field(Box::new(Var::Simple(Symbol::from("foo"))),Symbol::from("perro"))),
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast = make_ast(Exp::Var(
+        make_var(VarKind::Field(
+            boxed_var(VarKind::Simple(Symbol::from("foo"))),
+            Symbol::from("perro")))
+    ));
     let mut type_env = initial_type_env();
     let mut value_env = initial_value_env();
     let foo_type = Arc::new(TigerType::TRecord(
@@ -247,7 +201,7 @@ fn varexp_fieldvar_field_inexistente() {
     value_env.insert(Symbol::from("foo"), EnvEntry::Var{
         ty: foo_type,
     });
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::FieldDoesNotExist(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -257,13 +211,11 @@ fn varexp_fieldvar_field_inexistente() {
 
 #[test]
 fn varexp_fieldvar_sobre_tipo_no_record() {
-    let exp = Exp {
-        node: _Exp::Var(Var::Field(Box::new(Var::Simple(Symbol::from("foo"))),Symbol::from("bar"))),
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast = make_ast(Exp::Var(
+        make_var(VarKind::Field(
+            boxed_var(VarKind::Simple(Symbol::from("foo"))),
+            Symbol::from("bar")))
+    ));
     let mut type_env = initial_type_env();
     let mut value_env = initial_value_env();
     let foo_type = Arc::new(TigerType::TInt(R::RW));
@@ -271,7 +223,7 @@ fn varexp_fieldvar_sobre_tipo_no_record() {
     value_env.insert(Symbol::from("foo"), EnvEntry::Var{
         ty: foo_type,
     });
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::NotRecordType(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -281,20 +233,10 @@ fn varexp_fieldvar_sobre_tipo_no_record() {
 
 #[test]
 fn varexp_subscriptvar_ok() {
-    let exp = Exp {
-        node: _Exp::Var(
-            Var::Subscript(Box::new(Var::Simple(Symbol::from("foo"))),
-            Box::new(Exp {
-                node: _Exp::Int(0),
-                pos: Pos {
-                    line: 0,
-                    column: 0,
-            }}))),
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast = make_ast(Exp::Var(
+        make_var(VarKind::Subscript(boxed_var(VarKind::Simple(Symbol::from("foo"))),
+        boxed_ast(Exp::Int(0))),
+    )));
     let mut type_env = initial_type_env();
     let mut value_env = initial_value_env();
     let foo_type = Arc::new(TigerType::TArray(
@@ -305,30 +247,22 @@ fn varexp_subscriptvar_ok() {
     value_env.insert(Symbol::from("foo"), EnvEntry::Var{
         ty: foo_type,
     });
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn varexp_subscriptvar_indice_no_entero() {
-    let exp = Exp {
-        node: _Exp::Var(
-            Var::Subscript(Box::new(Var::Simple(Symbol::from("foo"))),
-            Box::new(Exp {
-                node: _Exp::String(String::from("una string de indice :o")),
-                pos: Pos {
-                    line: 0,
-                    column: 0,
-            }}))),
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast = make_ast(Exp::Var(
+        make_var(VarKind::Subscript(
+            boxed_var(VarKind::Simple(Symbol::from("foo"))),
+            boxed_ast(Exp::String(String::from("una string de indice :o"))),
+        ))
+    ));
     let mut type_env = initial_type_env();
     let mut value_env = initial_value_env();
     let foo_type = Arc::new(TigerType::TArray(
@@ -339,7 +273,7 @@ fn varexp_subscriptvar_indice_no_entero() {
     value_env.insert(Symbol::from("foo"), EnvEntry::Var{
         ty: foo_type,
     });
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::SubscriptNotInteger(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -349,20 +283,10 @@ fn varexp_subscriptvar_indice_no_entero() {
 
 #[test]
 fn varexp_subscriptvar_no_array() {
-    let exp = Exp {
-        node: _Exp::Var(
-            Var::Subscript(Box::new(Var::Simple(Symbol::from("foo"))),
-            Box::new(Exp {
-                node: _Exp::Int(0),
-                pos: Pos {
-                    line: 0,
-                    column: 0,
-            }}))),
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast = make_ast(Exp::Var(
+        make_var(VarKind::Subscript(boxed_var(VarKind::Simple(Symbol::from("foo"))),
+        boxed_ast(Exp::Int(0))),
+    )));
     let mut type_env = initial_type_env();
     let mut value_env = initial_value_env();
     let foo_type = Arc::new(TigerType::TInt(R::RW));
@@ -370,7 +294,7 @@ fn varexp_subscriptvar_no_array() {
     value_env.insert(Symbol::from("foo"), EnvEntry::Var{
         ty: foo_type,
     });
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::NotArrayType(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -380,49 +304,37 @@ fn varexp_subscriptvar_no_array() {
 
 #[test]
 fn callexp_ok() {
-    let exp = Exp {
-        node: _Exp::Call {
-            func: Symbol::from("f"),
-            args: vec![],
-        },
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast = make_ast(Exp::Call {
+        func: Symbol::from("f"),
+        args: vec![],
+    });
     let type_env = initial_type_env();
     let mut value_env = initial_value_env();
     value_env.insert(Symbol::from("f"), EnvEntry::Func {
         formals: vec![],
         result: Arc::new(TigerType::TUnit),
     });
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TUnit => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TUnit => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn callexp_args_de_mas() {
-    let exp = Exp {
-        node: _Exp::Call {
-            func: Symbol::from("f"),
-            args: vec![Exp {
-                node: _Exp::Int(1),
-                pos: Pos {line: 0, column: 0}
-            }],
-        },
-        pos: Pos {line: 0, column: 0}
-    };
+    let ast = make_ast(Exp::Call {
+        func: Symbol::from("f"),
+        args: vec![make_ast(Exp::Int(1))],
+    });
     let type_env = initial_type_env();
     let mut value_env = initial_value_env();
     value_env.insert(Symbol::from("f"), EnvEntry::Func {
         formals: vec![],
         result: Arc::new(TigerType::TUnit),
     });
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::TooManyArguments(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -432,20 +344,17 @@ fn callexp_args_de_mas() {
 
 #[test]
 fn callexp_args_de_menos() {
-    let exp = Exp {
-        node: _Exp::Call {
-            func: Symbol::from("f"),
-            args: vec![],
-        },
-        pos: Pos {line: 0, column: 0}
-    };
+    let ast = make_ast(Exp::Call {
+        func: Symbol::from("f"),
+        args: vec![],
+    });
     let type_env = initial_type_env();
     let mut value_env = initial_value_env();
     value_env.insert(Symbol::from("f"), EnvEntry::Func {
         formals: vec![Arc::new(TigerType::TInt(R::RW))],
         result: Arc::new(TigerType::TUnit),
     });
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::TooFewArguments(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -455,19 +364,13 @@ fn callexp_args_de_menos() {
 
 #[test]
 fn callexp_funcion_no_declarada() {
-    let exp = Exp {
-        node: _Exp::Call {
-            func: Symbol::from("f"),
-            args: vec![],
-        },
-        pos: Pos {
-            line: 0,
-            column: 0,
-        }
-    };
+    let ast = make_ast(Exp::Call {
+        func: Symbol::from("f"),
+        args: vec![],
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::UndeclaredFunction(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -477,37 +380,31 @@ fn callexp_funcion_no_declarada() {
 
 #[test]
 fn opexp_ok() {
-    let exp = Exp {
-        node: _Exp::Op {
-            left: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
-            oper: Oper::PlusOp,
-            right: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
-        },
-        pos: Pos {line: 0, column: 0}
-    };
+    let ast = make_ast(Exp::Op {
+        left: boxed_ast(Exp::Int(1)),
+        oper: Oper::PlusOp,
+        right: boxed_ast(Exp::Int(1)),
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn opexp_tipos_distintos() {
-    let exp = Exp {
-        node: _Exp::Op {
-            left: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
-            oper: Oper::PlusOp,
-            right: Box::new(Exp {node: _Exp::String(String::from("perro")), pos: Pos {line: 0, column: 0}}),
-        },
-        pos: Pos {line: 0, column: 0}
-    };
+    let ast = make_ast(Exp::Op {
+        left: boxed_ast(Exp::Int(1)),
+        oper: Oper::PlusOp,
+        right: boxed_ast(Exp::String(String::from("perro"))),
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::TypeMismatch(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -517,13 +414,10 @@ fn opexp_tipos_distintos() {
 
 #[test]
 fn recordexp_ok() {
-    let exp = Exp {
-        node: _Exp::Record {
-            fields: vec![(Symbol::from("baz"), Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}))],
-            typ: Symbol::from("FooType"),
-        },
-        pos: Pos {line: 0, column: 0}
-    };
+    let ast = make_ast(Exp::Record {
+        fields: vec![(Symbol::from("baz"), boxed_ast(Exp::Int(1)))],
+        typ: Symbol::from("FooType"),
+    });
     let mut type_env = initial_type_env();
     let value_env = initial_value_env();
     let field_type = Arc::new(TigerType::TInt(R::RW));
@@ -532,25 +426,23 @@ fn recordexp_ok() {
                 field_type,
                 0)], TypeId::new()));
     type_env.insert(Symbol::from("FooType"), foo_type.clone());
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(return_type) => assert!(return_type == foo_type),
+        Ok(AST{typ, ..}) if *typ == *foo_type => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn recordexp_tipo_inexistente() {
-    let exp = Exp {
-        node: _Exp::Record {
-            fields: vec![(Symbol::from("baz"), Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}))],
-            typ: Symbol::from("FooType"),
-        },
-        pos: Pos {line: 0, column: 0}
-    };
+    let ast = make_ast(Exp::Record {
+        fields: vec![(Symbol::from("baz"), boxed_ast(Exp::Int(1)))],
+        typ: Symbol::from("FooType"),
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::UndeclaredType(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -560,17 +452,14 @@ fn recordexp_tipo_inexistente() {
 
 #[test]
 fn recordexp_con_tipo_no_record() {
-    let exp = Exp {
-        node: _Exp::Record {
-            fields: vec![(Symbol::from("baz"), Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}))],
-            typ: Symbol::from("FooType"),
-        },
-        pos: Pos {line: 0, column: 0}
-    };
+    let ast = make_ast(Exp::Record {
+        fields: vec![(Symbol::from("baz"), boxed_ast(Exp::Int(1)))],
+        typ: Symbol::from("FooType"),
+    });
     let mut type_env = initial_type_env();
     let value_env = initial_value_env();
     type_env.insert(Symbol::from("FooType"), Arc::new(TigerType::TInt(R::RW)));
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::NotRecordType(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -580,11 +469,11 @@ fn recordexp_con_tipo_no_record() {
 
 #[test]
 fn arrayexp_ok() {
-    let exp = Exp {node: _Exp::Array {
+    let ast = make_ast(Exp::Array {
         typ: Symbol::from("FooType"),
-        size: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
-        init: Box::new(Exp {node: _Exp::Int(2), pos: Pos {line: 0, column: 0}}),
-    }, pos: Pos {line: 0, column: 0}};
+        size: boxed_ast(Exp::Int(1)),
+        init: boxed_ast(Exp::Int(2))
+    });
     let mut type_env = initial_type_env();
     let value_env = initial_value_env();
     let foo_type = Arc::new(TigerType::TArray(
@@ -592,20 +481,21 @@ fn arrayexp_ok() {
         TypeId::new(),
     ));
     type_env.insert(Symbol::from("FooType"), foo_type.clone());
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(return_type) => assert!(return_type == foo_type),
+        Ok(AST{typ, ..}) if *typ == *foo_type => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(..) => panic!("array")
     }
 }
 
 #[test]
 fn arrayexp_size_no_int() {
-    let exp = Exp {node: _Exp::Array {
+    let ast = make_ast(Exp::Array {
         typ: Symbol::from("FooType"),
-        size: Box::new(Exp {node: _Exp::String(String::from("perro")), pos: Pos {line: 0, column: 0}}),
-        init: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
-    }, pos: Pos {line: 0, column: 0}};
+        size: boxed_ast(Exp::String(String::from("perro"))),
+        init: boxed_ast(Exp::Int(2))
+    });
     let mut type_env = initial_type_env();
     let value_env = initial_value_env();
     let foo_type = Arc::new(TigerType::TArray(
@@ -613,7 +503,7 @@ fn arrayexp_size_no_int() {
         TypeId::new(),
     ));
     type_env.insert(Symbol::from("FooType"), foo_type);
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::NonIntegerSize(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -623,11 +513,11 @@ fn arrayexp_size_no_int() {
 
 #[test]
 fn arrayexp_tipos_distintos() {
-    let exp = Exp {node: _Exp::Array {
+    let ast = make_ast(Exp::Array {
         typ: Symbol::from("FooType"),
-        size: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
-        init: Box::new(Exp {node: _Exp::String(String::from("perro")), pos: Pos {line: 0, column: 0}}),
-    }, pos: Pos {line: 0, column: 0}};
+        size: boxed_ast(Exp::Int(1)),
+        init: boxed_ast(Exp::String(String::from("perro")))
+    });
     let mut type_env = initial_type_env();
     let value_env = initial_value_env();
     let foo_type = Arc::new(TigerType::TArray(
@@ -635,7 +525,7 @@ fn arrayexp_tipos_distintos() {
         TypeId::new(),
     ));
     type_env.insert(Symbol::from("FooType"), foo_type);
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::TypeMismatch(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -645,16 +535,16 @@ fn arrayexp_tipos_distintos() {
 
 #[test]
 fn arrayexp_tipo_no_array() {
-    let exp = Exp {node: _Exp::Array {
+    let ast = make_ast(Exp::Array {
         typ: Symbol::from("FooType"),
-        size: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
-        init: Box::new(Exp {node: _Exp::String(String::from("perro")), pos: Pos {line: 0, column: 0}}),
-    }, pos: Pos {line: 0, column: 0}};
+        size: boxed_ast(Exp::Int(1)),
+        init: boxed_ast(Exp::String(String::from("perro")))
+    });
     let mut type_env = initial_type_env();
     let value_env = initial_value_env();
     let foo_type = Arc::new(TigerType::TInt(R::RW));
     type_env.insert(Symbol::from("FooType"), foo_type);
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::NotArrayType(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -664,14 +554,14 @@ fn arrayexp_tipo_no_array() {
 
 #[test]
 fn arrayexp_tipo_no_existe() {
-    let exp = Exp {node: _Exp::Array {
+    let ast = make_ast(Exp::Array {
         typ: Symbol::from("FooType"),
-        size: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
-        init: Box::new(Exp {node: _Exp::String(String::from("perro")), pos: Pos {line: 0, column: 0}}),
-    }, pos: Pos {line: 0, column: 0}};
+        size: boxed_ast(Exp::Int(1)),
+        init: boxed_ast(Exp::String(String::from("perro")))
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::UndeclaredType(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -681,53 +571,50 @@ fn arrayexp_tipo_no_existe() {
 
 #[test]
 fn seqexp_ok() {
-    let exp = Exp {
-        node: _Exp::Seq(vec![
-            Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}},
-            Exp {node: _Exp::Int(2), pos: Pos {line: 0, column: 0}},
-        ]),
-        pos: Pos {line: 0, column: 0}
-    };
+    let ast = make_ast(Exp::Seq(vec![
+        make_ast(Exp::Int(1)),
+        make_ast(Exp::Int(1)),
+    ]));
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
-// Se puede testear algo mas de _Exp::Seq? Hay alguna condicion del ultimo tipo?
+// Se puede testear algo mas de Exp::Seq? Hay alguna condicion del ultimo tipo?
 
 #[test]
 fn assignexp_ok() {
-    let exp = Exp {node: _Exp::Assign{
-        var: Var::Simple(Symbol::from("foo")),
-        exp: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
-    }, pos: Pos {line: 0, column: 0}};
+    let ast = make_ast(Exp::Assign{
+        var: make_var(VarKind::Simple(Symbol::from("foo"))),
+        exp: boxed_ast(Exp::Int(1)),
+    });
     let type_env = initial_type_env();
     let mut value_env = initial_value_env();
     let env_entry = EnvEntry::Var{
         ty: Arc::new(TigerType::TInt(R::RW)),
     };
     value_env.insert(Symbol::from("foo"), env_entry);
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TUnit => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TUnit => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn assignexp_variable_no_existe() {
-    let exp = Exp {node: _Exp::Assign{
-        var: Var::Simple(Symbol::from("foo")),
-        exp: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
-    }, pos: Pos {line: 0, column: 0}};
+    let ast = make_ast(Exp::Assign{
+        var: make_var(VarKind::Simple(Symbol::from("foo"))),
+        exp: boxed_ast(Exp::Int(1)),
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::UndeclaredSimpleVar(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -737,17 +624,17 @@ fn assignexp_variable_no_existe() {
 
 #[test]
 fn assignexp_tipos_distintos() {
-    let exp = Exp {node: _Exp::Assign{
-        var: Var::Simple(Symbol::from("foo")),
-        exp: Box::new(Exp {node: _Exp::String(String::from("perro")), pos: Pos {line: 0, column: 0}}),
-    }, pos: Pos {line: 0, column: 0}};
+    let ast = make_ast(Exp::Assign{
+        var: make_var(VarKind::Simple(Symbol::from("foo"))),
+        exp: boxed_ast(Exp::String(String::from("perro"))),
+    });
     let type_env = initial_type_env();
     let mut value_env = initial_value_env();
     let env_entry = EnvEntry::Var{
         ty: Arc::new(TigerType::TInt(R::RW)),
     };
     value_env.insert(Symbol::from("foo"), env_entry);
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::TypeMismatch(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -757,17 +644,17 @@ fn assignexp_tipos_distintos() {
 
 #[test]
 fn assignexp_variable_read_only() {
-    let exp = Exp {node: _Exp::Assign{
-        var: Var::Simple(Symbol::from("i")),
-        exp: Box::new(Exp {node: _Exp::Int(2), pos: Pos {line: 0, column: 0}}),
-    }, pos: Pos {line: 0, column: 0}};
+    let ast = make_ast(Exp::Assign{
+        var: make_var(VarKind::Simple(Symbol::from("i"))),
+        exp: boxed_ast(Exp::Int(2)),
+    });
     let type_env = initial_type_env();
     let mut value_env = initial_value_env();
     let env_entry = EnvEntry::Var{
         ty: Arc::new(TigerType::TInt(R::RO)),
     };
     value_env.insert(Symbol::from("i"), env_entry);
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::ReadOnlyAssignment(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -777,33 +664,31 @@ fn assignexp_variable_read_only() {
 
 #[test]
 fn ifexp_ok() {
-    let exp = Exp {node: _Exp::If {
-        test: Box::new(Exp {node: _Exp::Int(0), pos: Pos {line: 0, column: 0}}),
-        then_: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
-        else_: Some(Box::new(Exp {node: _Exp::Int(2), pos: Pos {line: 0, column: 0}}))
-    }
-    , pos: Pos {line: 0, column: 0}};
+    let ast = make_ast(Exp::If {
+        test: boxed_ast(Exp::Int(0)),
+        then_: boxed_ast(Exp::Int(1)),
+        else_: Some(boxed_ast(Exp::Int(2)))
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RO) || *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn ifexp_test_no_entero() {
-    let exp = Exp {node: _Exp::If {
-        test: Box::new(Exp {node: _Exp::String(String::from("perro")), pos: Pos {line: 0, column: 0}}),
-        then_: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
-        else_: Some(Box::new(Exp {node: _Exp::Int(2), pos: Pos {line: 0, column: 0}}))
-    }
-    , pos: Pos {line: 0, column: 0}};
+    let ast = make_ast(Exp::If {
+        test: boxed_ast(Exp::String(String::from("perro"))),
+        then_: boxed_ast(Exp::Int(1)),
+        else_: Some(boxed_ast(Exp::Int(2)))
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::NonIntegerCondition(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -813,15 +698,14 @@ fn ifexp_test_no_entero() {
 
 #[test]
 fn ifexp_tipos_then_else_distintos() {
-    let exp = Exp {node: _Exp::If {
-        test: Box::new(Exp {node: _Exp::Int(0), pos: Pos {line: 0, column: 0}}),
-        then_: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
-        else_: Some(Box::new(Exp {node: _Exp::String(String::from("perro")), pos: Pos {line: 0, column: 0}})),
-    }
-    , pos: Pos {line: 0, column: 0}};
+    let ast = make_ast(Exp::If {
+        test: boxed_ast(Exp::Int(0)),
+        then_: boxed_ast(Exp::Int(1)),
+        else_: Some(boxed_ast(Exp::String(String::from("perro")))),
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::ThenElseTypeMismatch(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -831,15 +715,14 @@ fn ifexp_tipos_then_else_distintos() {
 
 #[test]
 fn ifexp_sin_else_no_unit() {
-    let exp = Exp {node: _Exp::If {
-        test: Box::new(Exp {node: _Exp::Int(0), pos: Pos {line: 0, column: 0}}),
-        then_: Box::new(Exp {node: _Exp::Int(1), pos: Pos {line: 0, column: 0}}),
+    let ast = make_ast(Exp::If {
+        test: boxed_ast(Exp::Int(0)),
+        then_: boxed_ast(Exp::Int(1)),
         else_: None
-    }
-    , pos: Pos {line: 0, column: 0}};
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::NonUnitBody(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -849,29 +732,29 @@ fn ifexp_sin_else_no_unit() {
 
 #[test]
 fn whileexp_ok() {
-    let exp = Exp {node: _Exp::While {
-        test: Box::new(Exp {node: _Exp::Int(0), pos: Pos {line: 0, column: 0}}),
-        body: Box::new(Exp {node: _Exp::Unit, pos: Pos {line: 0, column: 0}}),
-    }, pos: Pos {line: 0, column: 0}};
+    let ast = make_ast(Exp::While {
+        test: boxed_ast(Exp::Int(0)),
+        body: boxed_ast(Exp::Unit),
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TUnit => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TUnit => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn whileexp_condicion_no_entera() {
-    let exp = Exp {node: _Exp::While {
-        test: Box::new(Exp {node: _Exp::Unit, pos: Pos {line: 0, column: 0}}),
-        body: Box::new(Exp {node: _Exp::Unit, pos: Pos {line: 0, column: 0}}),
-    }, pos: Pos {line: 0, column: 0}};
+    let ast = make_ast(Exp::While {
+        test: boxed_ast(Exp::Unit),
+        body: boxed_ast(Exp::Unit),
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::NonIntegerCondition(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -881,54 +764,56 @@ fn whileexp_condicion_no_entera() {
 
 #[test]
 fn forexp_ok() {
-    let exp = Exp {node: _Exp::For {
+    let ast = make_ast(Exp::For {
         var: Symbol::from("i"),
         escape: false,
-        lo: Box::new(Exp { node: _Exp::Int(1), pos: Pos {line: 0, column: 0,}}),
-        hi: Box::new(Exp { node: _Exp::Int(10), pos: Pos {line: 0, column: 0,}}),
-        body: Box::new(Exp { node: _Exp::Unit, pos: Pos {line: 0, column: 0,}}),
-    }, pos: Pos {line: 0, column: 0}};
+        lo: boxed_ast(Exp::Int(1)),
+        hi: boxed_ast(Exp::Int(10)),
+        body: boxed_ast(Exp::Unit),
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TUnit => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TUnit => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn forexp_iterador_es_usable() {
-    let exp = Exp {node: _Exp::For {
+    let ast = make_ast(Exp::For {
         var: Symbol::from("i"),
         escape: false,
-        lo: Box::new(Exp { node: _Exp::Int(1), pos: Pos {line: 0, column: 0,}}),
-        hi: Box::new(Exp { node: _Exp::Int(10), pos: Pos {line: 0, column: 0,}}),
-        body: boxed_exp(_Exp::Seq(vec![possed_exp(_Exp::Var(Var::Simple(Symbol::from("i")))), possed_exp(_Exp::Unit)])),
-    }, pos: Pos {line: 0, column: 0}};
+        lo: boxed_ast(Exp::Int(1)),
+        hi: boxed_ast(Exp::Int(10)),
+        body: boxed_ast(Exp::Seq(vec![
+            make_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("i"))))),
+            make_ast(Exp::Unit)])),
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TUnit => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TUnit => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn forexp_body_no_es_unit() {
-    let exp = Exp {node: _Exp::For {
+    let ast = make_ast(Exp::For {
         var: Symbol::from("i"),
         escape: false,
-        lo: Box::new(Exp { node: _Exp::Int(1), pos: Pos {line: 0, column: 0,}}),
-        hi: Box::new(Exp { node: _Exp::Int(10), pos: Pos {line: 0, column: 0,}}),
-        body: Box::new(Exp { node: _Exp::Int(2), pos: Pos {line: 0, column: 0,}}),
-    }, pos: Pos {line: 0, column: 0}};
+        lo: boxed_ast(Exp::Int(1)),
+        hi: boxed_ast(Exp::Int(10)),
+        body: boxed_ast(Exp::Int(2)),
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::NonUnitBody(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -938,16 +823,16 @@ fn forexp_body_no_es_unit() {
 
 #[test]
 fn forexp_lo_no_es_int() {
-    let exp = Exp {node: _Exp::For {
+    let ast = make_ast(Exp::For {
         var: Symbol::from("i"),
         escape: false,
-        lo: Box::new(Exp { node: _Exp::Unit, pos: Pos {line: 0, column: 0,}}),
-        hi: Box::new(Exp { node: _Exp::Int(10), pos: Pos {line: 0, column: 0,}}),
-        body: Box::new(Exp { node: _Exp::Unit, pos: Pos {line: 0, column: 0,}}),
-    }, pos: Pos {line: 0, column: 0}};
+        lo: boxed_ast(Exp::Unit),
+        hi: boxed_ast(Exp::Int(10)),
+        body: boxed_ast(Exp::Unit),
+    });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::NonIntegerForRange(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -957,16 +842,16 @@ fn forexp_lo_no_es_int() {
 
 #[test]
 fn forexp_hi_no_es_int() {
-    let exp = Exp {node: _Exp::For {
+    let ast = make_ast(Exp::For {
         var: Symbol::from("i"),
         escape: false,
-        lo: Box::new(Exp { node: _Exp::Int(1), pos: Pos {line: 0, column: 0,}}),
-        hi: Box::new(Exp { node: _Exp::Unit, pos: Pos {line: 0, column: 0,}}),
-        body: Box::new(Exp { node: _Exp::Unit, pos: Pos {line: 0, column: 0,}}),
-    }, pos: Pos {line: 0, column: 0}};
-        let type_env = initial_type_env();
+        lo: boxed_ast(Exp::Int(1)),
+        hi: boxed_ast(Exp::Unit),
+        body: boxed_ast(Exp::Unit),
+    });
+    let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::NonIntegerForRange(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -976,67 +861,67 @@ fn forexp_hi_no_es_int() {
 
 #[test]
 fn letexp_vardec_sin_tipo_ok() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![Dec::VarDec(
             _VarDec::new(
                 Symbol::from("foo"),
                 None,
-                boxed_exp(_Exp::Int(4))
+                boxed_ast(Exp::Int(4))
             ),
             Pos{line: 0, column: 0}
         )],
-        body: boxed_exp(_Exp::Var(Var::Simple(Symbol::from("foo"))))
+        body: boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("foo")))))
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn letexp_vardec_con_tipo_ok() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![Dec::VarDec(
             _VarDec::new(
                 Symbol::from("foo"),
                 Some(Symbol::from("int")),
-                boxed_exp(_Exp::Int(4)),
+                boxed_ast(Exp::Int(4)),
             ),
             Pos{line: 0, column: 0}
         )],
-        body: boxed_exp(_Exp::Var(Var::Simple(Symbol::from("foo"))))
+        body: boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("foo")))))
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
 
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn letexp_vardec_tipo_no_esta_declarado() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![Dec::VarDec(
             _VarDec::new(
                 Symbol::from("foo"),
                 Some(Symbol::from("un_tipo_no_declarado")),
-                boxed_exp(_Exp::Int(4)),
+                boxed_ast(Exp::Int(4)),
             ),
             Pos{line: 0, column: 0}
         )],
-        body: boxed_exp(_Exp::Unit)
+        body: boxed_ast(Exp::Unit)
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::UndeclaredType(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -1046,20 +931,20 @@ fn letexp_vardec_tipo_no_esta_declarado() {
 
 #[test]
 fn letexp_vardec_tipos_distintos() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![Dec::VarDec(
             _VarDec::new(
                 Symbol::from("foo"),
                 Some(Symbol::from("string")),
-                boxed_exp(_Exp::Int(4))
+                boxed_ast(Exp::Int(4))
             ),
             Pos{line: 0, column: 0}
         )],
-        body: boxed_exp(_Exp::Unit)
+        body: boxed_ast(Exp::Unit)
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::TypeMismatch(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -1069,7 +954,7 @@ fn letexp_vardec_tipos_distintos() {
 
 #[test]
 fn letexp_typedec_name_ok() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![
             Dec::TypeDec(vec![(
                 _TypeDec::new(
@@ -1082,26 +967,26 @@ fn letexp_typedec_name_ok() {
                 _VarDec::new(
                     Symbol::from("foo"),
                     Some(Symbol::from("FooType")),
-                    boxed_exp(_Exp::Int(4))
+                    boxed_ast(Exp::Int(4))
                 ),
                 Pos{line: 0, column: 0}
             ),
         ],
-        body: boxed_exp(_Exp::Var(Var::Simple(Symbol::from("foo"))))
+        body: boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("foo")))))
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn letexp_typedec_array_ok() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![
             Dec::TypeDec(vec![(
                 _TypeDec::new(
@@ -1114,35 +999,35 @@ fn letexp_typedec_array_ok() {
                 _VarDec::new(
                     Symbol::from("foo"),
                     Some(Symbol::from("FooType")),
-                    boxed_exp(_Exp::Array {
+                    boxed_ast(Exp::Array {
                         typ: Symbol::from("FooType"),
-                        size:boxed_exp(_Exp::Int(1)),
-                        init: boxed_exp(_Exp::Int(2)),
+                        size:boxed_ast(Exp::Int(1)),
+                        init: boxed_ast(Exp::Int(2)),
                     })
                 ),
                 Pos{line: 0, column: 0}
             ),
         ],
-        body: boxed_exp(_Exp::Var(
-            Var::Subscript(
-                Box::new(Var::Simple(Symbol::from("foo"))),
-                boxed_exp(_Exp::Int(0))
-            )
+        body: boxed_ast(Exp::Var(
+            make_var(VarKind::Subscript(
+                boxed_var(VarKind::Simple(Symbol::from("foo"))),
+                boxed_ast(Exp::Int(0))
+            ))
         ))
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn letexp_typedec_record_ok() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![
             Dec::TypeDec(vec![(
                 _TypeDec::new(
@@ -1161,42 +1046,42 @@ fn letexp_typedec_record_ok() {
                 _VarDec::new(
                     Symbol::from("foo"),
                     Some(Symbol::from("FooType")),
-                    boxed_exp(_Exp::Record {
-                        fields: vec![(Symbol::from("bar"), boxed_exp(_Exp::Int(1)))],
+                    boxed_ast(Exp::Record {
+                        fields: vec![(Symbol::from("bar"), boxed_ast(Exp::Int(1)))],
                         typ: Symbol::from("FooType"),
                     })
                 ),
                 Pos{line: 0, column: 2}
             )],
-        body: boxed_exp(_Exp::Var(
-            Var::Field(
-                Box::new(Var::Simple(Symbol::from("foo"))),
+        body: boxed_ast(Exp::Var(
+            make_var(VarKind::Field(
+                boxed_var(VarKind::Simple(Symbol::from("foo"))),
                 Symbol::from("bar")
-            )
+            ))
         ))
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn letexp_typedec_recursion_infinita() {
-   let exp = possed_exp(_Exp::Let {
+   let ast =  make_ast(Exp::Let {
         decs: vec![Dec::TypeDec(vec![
             (_TypeDec::new(Symbol::from("FooType"), Ty::Name(Symbol::from("BaazType"))), Pos{line: 0, column: 0}),
             (_TypeDec::new(Symbol::from("BaazType"), Ty::Name(Symbol::from("FooType"))), Pos{line: 0, column: 0}),
         ])],
-        body: boxed_exp(_Exp::Unit)
+        body: boxed_ast(Exp::Unit)
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::TypeCycle(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -1205,27 +1090,27 @@ fn letexp_typedec_recursion_infinita() {
 }
 #[test]
 fn test_recursive_ok() {
-   let exp = possed_exp(_Exp::Let {
+   let ast =  make_ast(Exp::Let {
         decs: vec![Dec::TypeDec(vec![
             (_TypeDec::new(Symbol::from("C"), Ty::Name(Symbol::from("B"))), Pos{line: 0, column: 0}),
             (_TypeDec::new(Symbol::from("B"), Ty::Name(Symbol::from("A"))), Pos{line: 0, column: 0}),
             (_TypeDec::new(Symbol::from("A"), Ty::Name(Symbol::from("int"))), Pos{line: 0, column: 0}),
         ])],
-        body: boxed_exp(_Exp::Unit)
+        body: boxed_ast(Exp::Unit)
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TUnit => (),
-        Ok(..) => panic!("wrong type"),
+        Ok(AST{typ, ..}) if *typ == TigerType::TUnit => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(..) => panic!("type error"),
     }
 }
 
 #[test]
 fn letexp_typedec_referencia_tipo_inexistente() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![Dec::TypeDec(vec![(
             _TypeDec::new(
                 Symbol::from("FooType"),
@@ -1233,11 +1118,11 @@ fn letexp_typedec_referencia_tipo_inexistente() {
             ),
             Pos{line: 0, column: 0}
         )])],
-        body: boxed_exp(_Exp::Unit)
+        body: boxed_ast(Exp::Unit)
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::UndeclaredType(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -1247,7 +1132,7 @@ fn letexp_typedec_referencia_tipo_inexistente() {
 
 #[test]
 fn record_type_cycle_ok() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![
             Dec::TypeDec(vec![(
                 _TypeDec::new(
@@ -1271,19 +1156,19 @@ fn record_type_cycle_ok() {
                 _VarDec::new(
                     Symbol::from("foo"),
                     Some(Symbol::from("List")),
-                    boxed_exp(_Exp::Record {
+                    boxed_ast(Exp::Record {
                         fields: vec![
-                            (Symbol::from("head"), boxed_exp(_Exp::Int(1))),
-                            (Symbol::from("tail"), boxed_exp(_Exp::Record {
+                            (Symbol::from("head"), boxed_ast(Exp::Int(1))),
+                            (Symbol::from("tail"), boxed_ast(Exp::Record {
                                 fields: vec![
-                                    (Symbol::from("head"), boxed_exp(_Exp::Int(2))),
-                                    (Symbol::from("tail"), boxed_exp(_Exp::Record {
+                                    (Symbol::from("head"), boxed_ast(Exp::Int(2))),
+                                    (Symbol::from("tail"), boxed_ast(Exp::Record {
                                         fields: vec![
-                                            (Symbol::from("head"), boxed_exp(_Exp::Int(3))),
-                                            (Symbol::from("tail"), boxed_exp(_Exp::Record {
+                                            (Symbol::from("head"), boxed_ast(Exp::Int(3))),
+                                            (Symbol::from("tail"), boxed_ast(Exp::Record {
                                                 fields: vec![
-                                                    (Symbol::from("head"), boxed_exp(_Exp::Int(4))),
-                                                    (Symbol::from("tail"), boxed_exp(_Exp::Nil))
+                                                    (Symbol::from("head"), boxed_ast(Exp::Int(4))),
+                                                    (Symbol::from("tail"), boxed_ast(Exp::Nil))
                                                 ],
                                                 typ: Symbol::from("List"),
                                             }))
@@ -1299,26 +1184,26 @@ fn record_type_cycle_ok() {
                 ),
                 Pos{line: 0, column: 2}
             )],
-        body: boxed_exp(_Exp::Var(
-            Var::Field(
-                Box::new(Var::Simple(Symbol::from("foo"))),
+        body: boxed_ast(Exp::Var(
+            make_var(VarKind::Field(
+                boxed_var(VarKind::Simple(Symbol::from("foo"))),
                 Symbol::from("head")
-            )
+            ))
         ))
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn letexp_functiondec_ok() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![Dec::FunctionDec(vec![(
             _FunctionDec::new(
                 Symbol::from("foo"),
@@ -1328,25 +1213,25 @@ fn letexp_functiondec_ok() {
                     escape: false,
                 }],
                 None,
-                boxed_exp(_Exp::Unit)
+                boxed_ast(Exp::Unit)
             ),
             Pos{line: 0, column: 0}
         )])],
-        body: boxed_exp(_Exp::Unit)
+        body: boxed_ast(Exp::Unit)
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TUnit => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TUnit => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn letexp_functiondec_llamada_en_bloque_ok() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![
             Dec::FunctionDec(vec![(
                 _FunctionDec::new(
@@ -1357,7 +1242,7 @@ fn letexp_functiondec_llamada_en_bloque_ok() {
                         escape: false,
                     }],
                     Some(Symbol::from("int")),
-                    boxed_exp(_Exp::Var(Var::Simple(Symbol::from("arg1")))),
+                    boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("arg1"))))),
                 ),
                 Pos{line: 0, column: 0}
             )]),
@@ -1370,32 +1255,32 @@ fn letexp_functiondec_llamada_en_bloque_ok() {
                         escape: false,
                     }],
                     Some(Symbol::from("int")),
-                    boxed_exp(_Exp::Call {
+                    boxed_ast(Exp::Call {
                         func: Symbol::from("foo"),
-                        args: vec![possed_exp(_Exp::Var(Var::Simple(Symbol::from("arg2"))))],
+                        args: vec![make_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("arg2")))))],
                     })
                 ),
                 Pos{line: 0, column: 0}
             )]),
         ],
-        body: boxed_exp(_Exp::Call {
+        body: boxed_ast(Exp::Call {
             func: Symbol::from("baaz"),
-            args: vec![possed_exp(_Exp::Int(2))]
+            args: vec![make_ast(Exp::Int(2))]
         })
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn letexp_functiondec_body_no_tipa() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![Dec::FunctionDec(vec![(
             _FunctionDec::new(
                 Symbol::from("foo"),
@@ -1405,15 +1290,15 @@ fn letexp_functiondec_body_no_tipa() {
                     escape: false,
                 }],
                 None,
-                boxed_exp(_Exp::Var(Var::Simple(Symbol::from("baaz")))), // undeclared
+                boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("baaz"))))), // undeclared
             ),
             Pos{line: 0, column: 0}
         )])],
-        body: boxed_exp(_Exp::Unit)
+        body: boxed_ast(Exp::Unit)
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::UndeclaredSimpleVar(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -1423,7 +1308,7 @@ fn letexp_functiondec_body_no_tipa() {
 
 #[test]
 fn letexp_functiondec_body_distinto_result() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![Dec::FunctionDec(vec![(
             _FunctionDec::new(
                 Symbol::from("foo"),
@@ -1433,15 +1318,15 @@ fn letexp_functiondec_body_distinto_result() {
                     escape: false,
                 }],
                 None,
-                boxed_exp(_Exp::Int(2)),
+                boxed_ast(Exp::Int(2)),
             ),
             Pos{line: 0, column: 0}
         )])],
-        body: boxed_exp(_Exp::Unit)
+        body: boxed_ast(Exp::Unit)
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
         Err(TypeError::TypeMismatch(_)) => (),
         Err(type_error) => panic!("Wrong type error: {:?}", type_error),
@@ -1451,7 +1336,7 @@ fn letexp_functiondec_body_distinto_result() {
 
 #[test]
 fn letexp_functiondec_params_repetidos() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![Dec::FunctionDec(vec![(
             _FunctionDec::new(
                 Symbol::from("foo"),
@@ -1461,25 +1346,25 @@ fn letexp_functiondec_params_repetidos() {
                     escape: false,
                 }],
                 None,
-                boxed_exp(_Exp::Unit)
+                boxed_ast(Exp::Unit)
             ),
             Pos{line: 0, column: 0}
         )])],
-        body: boxed_exp(_Exp::Unit)
+        body: boxed_ast(Exp::Unit)
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TUnit => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TUnit => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn letexp_functiondec_nombres_repetidos() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![Dec::FunctionDec(vec![(
             _FunctionDec::new(
                 Symbol::from("foo"),
@@ -1489,25 +1374,25 @@ fn letexp_functiondec_nombres_repetidos() {
                     escape: false,
                 }],
                 None,
-                boxed_exp(_Exp::Unit)
+                boxed_ast(Exp::Unit)
             ),
             Pos{line: 0, column: 0}
         )])],
-        body: boxed_exp(_Exp::Unit)
+        body: boxed_ast(Exp::Unit)
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TUnit => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TUnit => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn letexp_functiondec_recursivas() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![Dec::FunctionDec(vec![(
             _FunctionDec::new(
                 Symbol::from("foo"),
@@ -1517,24 +1402,24 @@ fn letexp_functiondec_recursivas() {
                     escape: false,
                 }],
                 None,
-                boxed_exp(_Exp::Unit)
+                boxed_ast(Exp::Unit)
             ),
             Pos{line: 0, column: 0})])],
-        body: boxed_exp(_Exp::Unit)
+        body: boxed_ast(Exp::Unit)
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TUnit => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TUnit => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }
 
 #[test]
 fn letexp_todas_las_decs_ok() {
-    let exp = possed_exp(_Exp::Let {
+    let ast =  make_ast(Exp::Let {
         decs: vec![
             Dec::TypeDec(vec![(
                 _TypeDec::new(
@@ -1547,7 +1432,7 @@ fn letexp_todas_las_decs_ok() {
                 _VarDec::new(
                     Symbol::from("foo"),
                     Some(Symbol::from("FooType")),
-                    boxed_exp(_Exp::Int(4))
+                    boxed_ast(Exp::Int(4))
                 ),
                 Pos{line: 0, column: 0}
             ),
@@ -1560,22 +1445,22 @@ fn letexp_todas_las_decs_ok() {
                         escape: false,
                     }],
                     Some(Symbol::from("FooType")),
-                    boxed_exp(_Exp::Var(Var::Simple(Symbol::from("bar"))))
+                    boxed_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("bar")))))
                 ),
                 Pos{line: 0, column: 0}
             )]),
         ],
-        body: boxed_exp(_Exp::Call {
+        body: boxed_ast(Exp::Call {
             func: Symbol::from("baaz"),
-            args: vec![possed_exp(_Exp::Var(Var::Simple(Symbol::from("foo"))))]
+            args: vec![make_ast(Exp::Var(make_var(VarKind::Simple(Symbol::from("foo")))))]
         })
     });
     let type_env = initial_type_env();
     let value_env = initial_value_env();
-    let res = type_exp(&exp, &type_env, &value_env);
+    let res = type_exp(ast, &type_env, &value_env);
     match res {
-        Ok(tiger_type) if *tiger_type == TigerType::TInt(R::RW) => (),
-        Ok(tiger_type) => panic!("wrong type: {:?}", tiger_type),
+        Ok(AST{typ, ..}) if *typ == TigerType::TInt(R::RW) => (),
+        Ok(AST{typ, ..}) => panic!("wrong type: {:?}", typ),
         Err(type_error) => panic!("type error: {:?}", type_error)
     }
 }

--- a/src/tree/Tree.rs
+++ b/src/tree/Tree.rs
@@ -1,22 +1,22 @@
 use super::level::{Label, Temp};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Exp {
+pub enum AST {
     CONST(i64),
     NAME(Label),
     TEMP(Temp),
-    BINOP(BinOp, Box<Exp>, Box<Exp>),
-    MEM(Box<Exp>),
-    CALL(Box<Exp>, Vec<Exp>),
-    ESEQ(Box<Stm>, Box<Exp>)
+    BINOP(BinOp, Box<AST>, Box<AST>),
+    MEM(Box<AST>),
+    CALL(Box<AST>, Vec<AST>),
+    ESEQ(Box<Stm>, Box<AST>)
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Stm {
-    EXP(Box<Exp>),
-    MOVE(Box<Exp>, Box<Exp>),
-    JUMP(Exp, Vec<Label>),
-    CJUMP(RelOp, Exp, Exp, Label, Label),
+    EXP(Box<AST>),
+    MOVE(Box<AST>, Box<AST>),
+    JUMP(AST, Vec<Label>),
+    CJUMP(RelOp, AST, AST, Label, Label),
     SEQ(Box<Stm>, Box<Stm>),
     LABEL(Label)
 }
@@ -69,7 +69,7 @@ pub fn seq(mut stms: Vec<Stm>) -> Stm {
     let maybe_stm = stms.pop();
     match maybe_stm {
         Some(s) => Stm::SEQ(Box::new(s), Box::new(seq(stms))),
-        None => Stm::EXP(Box::new(Exp::CONST(0))),
+        None => Stm::EXP(Box::new(AST::CONST(0))),
     }
 }
 

--- a/src/tree/frame.rs
+++ b/src/tree/frame.rs
@@ -67,7 +67,7 @@ impl Frame {
         Access::InReg(newtemp())
     }
     // proc_name could be an str
-    pub fn external_call(proc_label: Label, args: Vec<Tree::Exp>) -> Tree::Exp {
+    pub fn external_call(proc_label: Label, args: Vec<Tree::AST>) -> Tree::AST {
         CALL(Box::new(NAME(proc_label)), args)
     }
 }

--- a/src/tree/mod.rs
+++ b/src/tree/mod.rs
@@ -82,7 +82,7 @@ pub fn initial_value_env() -> ValueEnviroment {
     value_env
 }
 
-use Tree::Exp::*;
+use Tree::AST::*;
 use Tree::Stm::*;
 use Tree::BinOp::*;
 use Tree::RelOp::*;

--- a/src/tree/translate/arrayexp.rs
+++ b/src/tree/translate/arrayexp.rs
@@ -2,14 +2,14 @@ use crate::ast::*;
 use crate::tree::translate::*;
 
 pub fn trans_exp(
-    Exp {node, ..}: &Exp,
+    AST {node, ..}: &AST,
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
-) -> Result<(Tree::Exp, Level, Vec<Fragment>), TransError> {
+) -> Result<(Tree::AST, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::Array { size, init, .. } => {
+        Exp::Array { size, init, .. } => {
             let (init_exp, init_level, init_frags) = super::trans_exp(init, level, value_env, breaks_stack, frags)?;
             let (size_exp, size_level, size_frags) = super::trans_exp(size, init_level, value_env, breaks_stack, init_frags)?;
             if let EnvEntry::Func {label, ..} = value_env.get("allocArray").expect("should be in initial value env") {

--- a/src/tree/translate/assignexp.rs
+++ b/src/tree/translate/assignexp.rs
@@ -3,14 +3,14 @@ use super::*;
 use Tree::Stm::*;
 
 pub fn trans_stm(
-    Exp { node, .. }: &Exp,
+    AST { node, .. }: &AST,
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
 ) -> Result<(Tree::Stm, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::Assign { var, exp } => {
+        Exp::Assign { var, exp } => {
             let (v, var_level, var_frags) = trans_var(var, level, value_env, breaks_stack, frags)?;
             let (e, exp_level, exp_frags) = super::trans_exp(exp, var_level, value_env, breaks_stack, var_frags)?;
             Ok((Move!(v, e), exp_level, exp_frags))

--- a/src/tree/translate/breakexp.rs
+++ b/src/tree/translate/breakexp.rs
@@ -2,14 +2,14 @@ use crate::ast::*;
 use crate::tree::*;
 
 pub fn trans_stm(
-    Exp { node, pos }: &Exp,
+    AST { node, pos, .. }: &AST,
     level: Level,
     _value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
 ) -> Result<(Tree::Stm, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::Break => {
+        Exp::Break => {
             let loop_end_label = match breaks_stack.last() {
                 Some(Some(l)) => l,
                 _ => return Err(TransError::BreakError(*pos)),
@@ -26,9 +26,10 @@ pub fn trans_stm(
 
 #[test]
 fn no_labels_error() {
-    let exp = Exp {
-        node: _Exp::Break,
+    let exp = AST {
+        node: Exp::Break,
         pos: Pos { line: 0, column: 0 },
+        typ: Arc::new(TigerType::TUnit)
     };
     let level = Level::outermost();
     let res = trans_stm(&exp, level, &initial_value_env(), &vec![], vec![]);
@@ -41,9 +42,10 @@ fn no_labels_error() {
 
 #[test]
 fn none_label_error() {
-    let exp = Exp {
-        node: _Exp::Break,
+    let exp = AST {
+        node: Exp::Break,
         pos: Pos { line: 0, column: 0 },
+        typ: Arc::new(TigerType::TUnit)
     };
     let level = Level::outermost();
     let res = trans_stm(&exp, level, &initial_value_env(), &vec![], vec![]);
@@ -56,9 +58,10 @@ fn none_label_error() {
 
 #[test]
 fn ok() {
-    let exp = Exp {
-        node: _Exp::Break,
+    let exp = AST {
+        node: Exp::Break,
         pos: Pos { line: 0, column: 0 },
+        typ: Arc::new(TigerType::TUnit)
     };
     let level = Level::outermost();
     let res = trans_stm(&exp, level, &initial_value_env(), &vec![Some(newlabel())], vec![]);

--- a/src/tree/translate/callexp.rs
+++ b/src/tree/translate/callexp.rs
@@ -2,14 +2,14 @@ use crate::ast::*;
 use crate::tree::*;
 
 pub fn trans_exp(
-    Exp { node, .. }: &Exp,
+    AST { node, .. }: &AST,
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
-) -> Result<(Tree::Exp, Level, Vec<Fragment>), TransError> {
+) -> Result<(Tree::AST, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::Call { func, args } => {
+        Exp::Call { func, args } => {
             let entry = value_env
                 .get(func)
                 .expect("typecheck should make sure this is found");
@@ -30,7 +30,7 @@ pub fn trans_exp(
 }
 
 pub fn trans_stm(
-    exp: &Exp,
+    exp: &AST,
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,

--- a/src/tree/translate/forexp.rs
+++ b/src/tree/translate/forexp.rs
@@ -2,14 +2,14 @@ use crate::ast::*;
 use crate::tree::*;
 
 pub fn trans_stm(
-    Exp { node, .. }: &Exp,
+    AST { node, .. }: &AST,
     mut level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
 ) -> Result<(Tree::Stm, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::For {
+        Exp::For {
             var,
             lo,
             hi,

--- a/src/tree/translate/ifexp.rs
+++ b/src/tree/translate/ifexp.rs
@@ -2,14 +2,14 @@ use crate::ast::*;
 use crate::tree::*;
 
 pub fn trans_exp(
-    Exp { node, .. }: &Exp,
+    AST { node, .. }: &AST,
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
-) -> Result<(Tree::Exp, Level, Vec<Fragment>), TransError> {
+) -> Result<(Tree::AST, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::If {
+        Exp::If {
             test,
             then_,
             else_: Some(else_),
@@ -60,14 +60,14 @@ pub fn trans_exp(
 }
 
 pub fn trans_stm(
-    Exp { node, .. }: &Exp,
+    AST { node, .. }: &AST,
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
 ) -> Result<(Tree::Stm, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::If {
+        Exp::If {
             test,
             then_,
             else_: None,
@@ -99,7 +99,7 @@ pub fn trans_stm(
                 then_frags,
             ))
         }
-        _Exp::If {
+        Exp::If {
             test,
             then_,
             else_: Some(else_),

--- a/src/tree/translate/intexp.rs
+++ b/src/tree/translate/intexp.rs
@@ -2,14 +2,14 @@ use crate::ast::*;
 use crate::tree::*;
 
 pub fn trans_exp(
-    Exp {node, ..}: &Exp,
+    AST {node, ..}: &AST,
     level: Level,
     _value_env: &ValueEnviroment,
     _breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
-) -> Result<(Tree::Exp, Level, Vec<Fragment>), TransError> {
+) -> Result<(Tree::AST, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::Int(i) => Ok((CONST(*i), level, frags)),
+        Exp::Int(i) => Ok((CONST(*i), level, frags)),
         _ => panic!()
     }
 }

--- a/src/tree/translate/letexp.rs
+++ b/src/tree/translate/letexp.rs
@@ -87,14 +87,14 @@ pub fn fundecs(
 }
 
 pub fn trans_exp(
-    Exp { node, .. }: &Exp,
+    AST { node, .. }: &AST,
     mut level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     mut frags: Vec<Fragment>,
-) -> Result<(Tree::Exp, Level, Vec<Fragment>), TransError> {
+) -> Result<(Tree::AST, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::Let { decs, body } => {
+        Exp::Let { decs, body } => {
             // TODO: this should be a fold
             let mut vardec_stms = vec![];
             let mut new_value_env = value_env.clone();

--- a/src/tree/translate/mod.rs
+++ b/src/tree/translate/mod.rs
@@ -22,47 +22,47 @@ mod whileexp;
 // We replaced all side-effects in Appel's book for move semantics because it's our compiler.
 // Also, no packing and unpacking. No conditionals either, only expressions and statements.
 fn trans_exp(
-    exp: &Exp,
+    exp: &AST,
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     prev_frags: Vec<Fragment>,
-) -> Result<(Tree::Exp, Level, Vec<Fragment>), TransError> {
+) -> Result<(Tree::AST, Level, Vec<Fragment>), TransError> {
     match exp {
-        Exp { node, .. } => match node {
-            _Exp::Var(var) => varexp::trans_var(var, level, value_env, breaks_stack, prev_frags),
-            _Exp::Unit => unitexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
-            _Exp::Nil => nilexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
-            _Exp::Int(_) => intexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
-            _Exp::String(_) => stringexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
-            _Exp::Call { .. } => callexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
-            _Exp::Op { .. } => opexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
-            _Exp::Record { .. } => recordexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
-            _Exp::If { .. } => ifexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
-            _Exp::Let { .. } => letexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
-            _Exp::Array { .. } => arrayexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
-            _Exp::Seq(_) => seqexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
+        AST { node, .. } => match node {
+            Exp::Var(var) => varexp::trans_var(var, level, value_env, breaks_stack, prev_frags),
+            Exp::Unit => unitexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
+            Exp::Nil => nilexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
+            Exp::Int(_) => intexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
+            Exp::String(_) => stringexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
+            Exp::Call { .. } => callexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
+            Exp::Op { .. } => opexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
+            Exp::Record { .. } => recordexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
+            Exp::If { .. } => ifexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
+            Exp::Let { .. } => letexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
+            Exp::Array { .. } => arrayexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
+            Exp::Seq(_) => seqexp::trans_exp(exp, level, value_env, breaks_stack, prev_frags),
             _ => panic!("cannot translate as exp!")
         },
     }
 }
 
 fn trans_stm(
-    exp: &Exp,
+    exp: &AST,
     levels: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     prev_frags: Vec<Fragment>,
 ) -> Result<(Tree::Stm, Level, Vec<Fragment>), TransError> {
     match exp {
-        Exp { node, .. } => match node {
-            _Exp::Break => breakexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
-            _Exp::Call { .. } => callexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
-            _Exp::Assign { .. } => assignexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
-            _Exp::Seq(_) => seqexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
-            _Exp::If { .. } => ifexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
-            _Exp::While { .. } => whileexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
-            _Exp::For { .. } => forexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
+        AST { node, .. } => match node {
+            Exp::Break => breakexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
+            Exp::Call { .. } => callexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
+            Exp::Assign { .. } => assignexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
+            Exp::Seq(_) => seqexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
+            Exp::If { .. } => ifexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
+            Exp::While { .. } => whileexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
+            Exp::For { .. } => forexp::trans_stm(exp, levels, value_env, breaks_stack, prev_frags),
             _ => {
                 let (exp, level, frags) = trans_exp(exp, levels, value_env, breaks_stack, prev_frags)?;
                 Ok((Tree::Stm::EXP(Box::new(exp)), level, frags))
@@ -72,13 +72,13 @@ fn trans_stm(
 }
 
 fn translate_many_exp(
-    exps: &[Exp],
+    exps: &[AST],
     mut level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     mut frags: Vec<Fragment>,
-) -> Result<(Vec<Tree::Exp>, Level, Vec<Fragment>), TransError> {
-    let mut interm_exps : Vec<Tree::Exp> = vec![];
+) -> Result<(Vec<Tree::AST>, Level, Vec<Fragment>), TransError> {
+    let mut interm_exps : Vec<Tree::AST> = vec![];
     for exp in exps {
         let (i, l, f) = trans_exp(exp, level, value_env, breaks_stack, frags)?;
         level = l;
@@ -88,15 +88,15 @@ fn translate_many_exp(
     Ok((interm_exps, level, frags))
 }
 
-pub fn translate(exp: &Exp) -> Result<(Vec<Fragment>), TransError> {
-    // let tiger_main = boxed_exp(_Exp::Let {
+pub fn translate(exp: &AST) -> Result<(Vec<Fragment>), TransError> {
+    // let tiger_main = boxed_ast(Exp::Let {
     //         decs: vec![Dec::FunctionDec(vec![(_FunctionDec{
     //             name: Label::from("_tigermain"),
     //             params: vec![],
     //             body: Box::new(exp),
     //             result: None,
     //         }, Pos{line: 0, column: 0})])],
-    //         body: boxed_exp(_Exp::Unit)
+    //         body: boxed_ast(Exp::Unit)
     //     });
     let level = Level::outermost();
     let value_env = initial_value_env();

--- a/src/tree/translate/nilexp.rs
+++ b/src/tree/translate/nilexp.rs
@@ -2,15 +2,15 @@ use crate::ast::*;
 use crate::tree::*;
 
 pub fn trans_exp(
-    Exp {node, ..}: &Exp,
+    AST {node, ..}: &AST,
     level: Level,
     _value_env: &ValueEnviroment,
     _breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
-) -> Result<(Tree::Exp, Level, Vec<Fragment>), TransError> {
+) -> Result<(Tree::AST, Level, Vec<Fragment>), TransError> {
     // Translates as a noop.
     match node {
-        _Exp::Nil => Ok((CONST(0), level, frags)),
+        Exp::Nil => Ok((CONST(0), level, frags)),
         _ => panic!("delegation error")
     }
 }

--- a/src/tree/translate/opexp.rs
+++ b/src/tree/translate/opexp.rs
@@ -3,14 +3,14 @@ use crate::tree::*;
 use crate::typecheck::{type_exp, TigerType};
 
 pub fn trans_exp(
-    Exp {node, ..}: &Exp,
+    AST {node, ..}: &AST,
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
-) -> Result<(Tree::Exp, Level, Vec<Fragment>), TransError> {
+) -> Result<(Tree::AST, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::Op{left, right, oper} => {
+        Exp::Op{left, right, oper} => {
             // match oper {
             // }
         }

--- a/src/tree/translate/recordexp.rs
+++ b/src/tree/translate/recordexp.rs
@@ -2,12 +2,12 @@ use crate::ast::*;
 use crate::tree::*;
 
 pub fn trans_exp(
-    Exp {node, ..}: &Exp,
+    AST {node, ..}: &AST,
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
-) -> Result<(Tree::Exp, Level, Vec<Fragment>), TransError> {
+) -> Result<(Tree::AST, Level, Vec<Fragment>), TransError> {
     Ok((CONST(0), level, frags)) // TODO
     // hay que llamar una external que pida memeoria dinamica
 }

--- a/src/tree/translate/seqexp.rs
+++ b/src/tree/translate/seqexp.rs
@@ -2,7 +2,7 @@ use crate::ast::*;
 use crate::tree::*;
 
 fn trans_seq(
-    exps: &[Exp],
+    exps: &[AST],
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
@@ -18,14 +18,14 @@ fn trans_seq(
 }
 
 pub fn trans_exp(
-    Exp { node, .. }: &Exp,
+    AST { node, .. }: &AST,
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
-) -> Result<(Tree::Exp, Level, Vec<Fragment>), TransError> {
+) -> Result<(Tree::AST, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::Seq(exps) => match exps.split_last() {
+        Exp::Seq(exps) => match exps.split_last() {
             Some((last, rest)) => {
                 let (prev_stms, prev_level, prev_frags) =
                     trans_seq(rest, level, value_env, breaks_stack, frags)?;
@@ -40,14 +40,14 @@ pub fn trans_exp(
 }
 
 pub fn trans_stm(
-    Exp { node, .. }: &Exp,
+    AST { node, .. }: &AST,
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
 ) -> Result<(Tree::Stm, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::Seq(exps) => match exps.split_last() {
+        Exp::Seq(exps) => match exps.split_last() {
             Some((last, rest)) => {
                 let (prev_stms, prev_level, seq_frags) =
                     trans_seq(rest, level, value_env, breaks_stack, frags)?;

--- a/src/tree/translate/stringexp.rs
+++ b/src/tree/translate/stringexp.rs
@@ -2,14 +2,14 @@ use crate::ast::*;
 use crate::tree::*;
 
 pub fn trans_exp(
-    Exp {node, ..}: &Exp,
+    AST {node, ..}: &AST,
     level: Level,
     _value_env: &ValueEnviroment,
     _breaks_stack: &Vec<Option<Label>>,
     mut frags: Vec<Fragment>,
-) -> Result<(Tree::Exp, Level, Vec<Fragment>), TransError> {
+) -> Result<(Tree::AST, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::String(s) => {
+        Exp::String(s) => {
             let l = newlabel();
             // Not sure if this is OK or I need one more fragment for the length
             frags.push(Fragment::ConstString(l.clone(), s.clone()));
@@ -21,12 +21,13 @@ pub fn trans_exp(
 
 #[test]
 fn ok() {
-    let exp = Exp {
-        node: _Exp::String(String::from("lorem ipsum")),
+    let exp = AST {
+        node: Exp::String(String::from("lorem ipsum")),
         pos: Pos {
             line: 0,
             column: 0,
-        }
+        },
+        typ: Arc::new(TigerType::TString)
     };
     let level = Level::outermost();
     let value_env = initial_value_env();

--- a/src/tree/translate/unitexp.rs
+++ b/src/tree/translate/unitexp.rs
@@ -2,15 +2,15 @@ use crate::ast::*;
 use crate::tree::*;
 
 pub fn trans_exp(
-    Exp {node, ..}: &Exp,
+    AST {node, ..}: &AST,
     level: Level,
     _value_env: &ValueEnviroment,
     _breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
-) -> Result<(Tree::Exp, Level, Vec<Fragment>), TransError> {
+) -> Result<(Tree::AST, Level, Vec<Fragment>), TransError> {
     // Translates as a noop.
     match node {
-        _Exp::Unit => Ok((CONST(0), level, frags)),
+        Exp::Unit => Ok((CONST(0), level, frags)),
         _ => panic!("delegation error")
     }
 }

--- a/src/tree/translate/varexp.rs
+++ b/src/tree/translate/varexp.rs
@@ -1,9 +1,9 @@
 use super::super::frame::STATIC_LINK_OFFSET;
 use crate::ast::*;
 use crate::tree::*;
-use Tree::Exp::*;
+use Tree::AST::*;
 
-pub fn generate_static_link(remaining_depth: i64) -> Tree::Exp {
+pub fn generate_static_link(remaining_depth: i64) -> Tree::AST {
     match remaining_depth {
         1 => MEM(Box::new(plus!(
             TEMP(Temp::FRAME_POINTER),
@@ -17,7 +17,7 @@ pub fn generate_static_link(remaining_depth: i64) -> Tree::Exp {
 }
 
 // Generates an expression that evaluates to the memory direction of the variable
-pub fn simplevar(access: Access, nesting_depth: i64, current_level: &Level) -> Tree::Exp {
+pub fn simplevar(access: Access, nesting_depth: i64, current_level: &Level) -> Tree::AST {
     let delta_depth = current_level.nesting_depth - nesting_depth;
     match access {
         Access::InReg(t) => {
@@ -38,21 +38,21 @@ pub fn simplevar(access: Access, nesting_depth: i64, current_level: &Level) -> T
 }
 
 pub fn trans_var(
-    var: &Var,
+    Var{kind, typ, pos}: &Var,
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
-) -> Result<(Tree::Exp, Level, Vec<Fragment>), TransError> {
+) -> Result<(Tree::AST, Level, Vec<Fragment>), TransError> {
     // TODO
-    match var {
-        Var::Simple(name) => Ok((CONST(0), level, frags)),
-        Var::Subscript(array, index) => Ok((CONST(0), level, frags)),
+    match kind {
+        VarKind::Simple(name) => Ok((CONST(0), level, frags)),
+        VarKind::Subscript(array, index) => Ok((CONST(0), level, frags)),
         // el arreglo es la direccion de memoria
         // le sumas el offset del indice
         // hay un runtime para fallar de forma linda
         // o dejar que se coma un segfault
-        Var::Field(record, field) => Ok((CONST(0), level, frags)),
+        VarKind::Field(record, field) => Ok((CONST(0), level, frags)),
         // cada campo tiene un numero de orden, con eso haces el corrimimento
     }
 }

--- a/src/tree/translate/whileexp.rs
+++ b/src/tree/translate/whileexp.rs
@@ -2,14 +2,14 @@ use crate::ast::*;
 use crate::tree::*;
 
 pub fn trans_stm(
-    Exp {node, ..}: &Exp,
+    AST {node, ..}: &AST,
     level: Level,
     value_env: &ValueEnviroment,
     breaks_stack: &Vec<Option<Label>>,
     frags: Vec<Fragment>,
 ) -> Result<(Tree::Stm, Level, Vec<Fragment>), TransError> {
     match node {
-        _Exp::While{test, body} => {
+        Exp::While{test, body} => {
             let (test_label, body_label, done_label) = (newlabel(), newlabel(), newlabel());
             let (test_exp, test_level, test_frags) = super::trans_exp(test, level, value_env, breaks_stack, frags)?;
             let mut new_breaks_stack = breaks_stack.clone();

--- a/src/typecheck/arrayexp.rs
+++ b/src/typecheck/arrayexp.rs
@@ -1,44 +1,46 @@
-use crate::ast::*;
 use crate::typecheck::*;
 
 pub fn typecheck(
-    exp: &Exp,
+    AST {node, pos, ..}: AST,
     type_env: &TypeEnviroment,
     value_env: &ValueEnviroment,
-) -> Result<Arc<TigerType>, TypeError> {
-    // Buscar el tipo del array en el type_env
-    // Si el tipo no existe, fallar.
-    // Si el tipo existe pero no es un array, fallar.
-    // Tipar el size. Si no es int, fallar.
-    // Tipar el init. Si no es del mismo tipo del array, fallar.
-    // Devolver TArray del tipo que encontramos en la tabla.
+) -> Result<AST, TypeError> {
+    // Get array type in value_env. If it's not an array, fail
+    // Type the size. If it's not int, fail
+    // Type the init. If it's not the same as the array, fail
+    // Return TArray of the type found in hte env
     use TigerType::*;
-    match exp {
-        Exp {
-            node:
-                _Exp::Array {
-                    typ: array_of_symbol,
-                    size: size_exp,
-                    init: init_exp,
-                },
-            pos,
-        } => match type_env.get(array_of_symbol) {
-            Some(tiger_type) => match &**tiger_type {
-                TArray(array_of_type, type_id) => match *type_exp(size_exp, type_env, value_env)? {
-                    TInt(_) => {
-                        let init_type = type_exp(init_exp, type_env, value_env)?;
-                        if **array_of_type == *init_type {
-                            Ok(Arc::new(TArray(array_of_type.clone(), *type_id)))
-                        } else {
-                            Err(TypeError::TypeMismatch(*pos))
+    match node {
+        Exp::Array {typ: array_of_symbol, size: size_exp, init: init_exp, } => {
+            let array_type = match type_env.get(&array_of_symbol) {
+                Some(tiger_type) => &**tiger_type,
+                None => return Err(TypeError::UndeclaredType(pos)),
+            };
+            match array_type {
+                TArray(array_of_type, type_id) => {
+                    let size_ast = type_exp(*size_exp, type_env, value_env)?;
+                    match *size_ast.typ {
+                        TInt(_) => {
+                            let init_ast = type_exp(*init_exp, type_env, value_env)?;
+                            if **array_of_type == *init_ast.typ {
+                                Ok(AST{
+                                    node: Exp::Array {
+                                        size: Box::new(size_ast),
+                                        init: Box::new(init_ast),
+                                        typ: array_of_symbol
+                                    },
+                                    pos,
+                                    typ: Arc::new(TArray(array_of_type.clone(), *type_id))})
+                            } else {
+                                Err(TypeError::TypeMismatch(pos))
+                            }
                         }
+                        _ => Err(TypeError::NonIntegerSize(pos)),
                     }
-                    _ => Err(TypeError::NonIntegerSize(*pos)),
                 },
-                _ => Err(TypeError::NotArrayType(*pos)),
-            },
-            None => Err(TypeError::UndeclaredType(*pos)),
-        },
+                _ => Err(TypeError::NotArrayType(pos)),
+            }
+        }
         _ => panic!("le llego algo nada que ver a arrayexp::tipar"),
     }
 }

--- a/src/typecheck/breakexp.rs
+++ b/src/typecheck/breakexp.rs
@@ -1,6 +1,8 @@
-use crate::ast::*;
-use crate::typecheck::*;
+use super::*;
 
-pub fn typecheck(_exp: &Exp, _type_env: &TypeEnviroment, _value_env: &ValueEnviroment) -> Result<Arc<TigerType>, TypeError> {
-    Ok(Arc::new(TigerType::TUnit))
+pub fn typecheck(AST{node, pos, ..}: AST, _type_env: &TypeEnviroment, _value_env: &ValueEnviroment) -> Result<AST, TypeError> {
+    match &node {
+        Exp::Break => Ok(AST {node, pos, typ: Arc::new(TigerType::TUnit)}),
+        _ => panic!("delegation error")
+    }
 }

--- a/src/typecheck/callexp.rs
+++ b/src/typecheck/callexp.rs
@@ -1,51 +1,39 @@
-use crate::ast::*;
-use crate::typecheck::*;
+use super::*;
 
 pub fn typecheck(
-    exp: &Exp,
+    AST{node, pos, ..}: AST,
     type_env: &TypeEnviroment,
     value_env: &ValueEnviroment,
-) -> Result<Arc<TigerType>, TypeError> {
-    let tipar_args = |args: &Vec<Exp>| -> Vec<Result<Arc<TigerType>, TypeError>> {
-        args.iter()
-            .map(|arg| type_exp(&*arg, type_env, value_env))
-            .rev()
-            .collect()
-    };
-    match exp {
-        Exp {
-            node:
-                _Exp::Call {
-                    func: function_symbol,
-                    args,
-                },
-            pos,
-        } => {
-            let (formals, return_type) = match value_env.get(function_symbol) {
+) -> Result<AST, TypeError> {
+    match node {
+        Exp::Call {func: function_symbol, args,} => {
+            let (formals, return_type) = match value_env.get(&function_symbol) {
                 Some(EnvEntry::Func {
                     formals, result, ..
                 }) => (formals, result),
-                Some(EnvEntry::Var { .. }) => return Err(TypeError::NotFunctionVar(*pos)),
-                None => return Err(TypeError::UndeclaredFunction(*pos)),
+                Some(EnvEntry::Var { .. }) => return Err(TypeError::NotFunctionVar(pos)),
+                None => return Err(TypeError::UndeclaredFunction(pos)),
             };
             if formals.len() > args.len() {
-                return Err(TypeError::TooFewArguments(*pos));
+                return Err(TypeError::TooFewArguments(pos));
             }
             if formals.len() < args.len() {
-                return Err(TypeError::TooManyArguments(*pos));
+                return Err(TypeError::TooManyArguments(pos));
             }
-            for (arg_result, formal_type) in tipar_args(args).into_iter().zip(formals) {
-                match &*(arg_result.clone()?) {
-                    TigerType::TUnit => return Err(TypeError::InvalidCallArgument(*pos)),
-                    _ => {
-                        if tipo_real(arg_result?, type_env) != *formal_type {
-                            return Err(TypeError::TypeMismatch(*pos));
-                        }
-                    }
-                }
-            }
-
-            Ok((*return_type).clone())
+            let typed_args : Vec<AST> = args
+                .into_iter() // into_iter moves the values instead of borrowing
+                .map(|arg| -> Result<AST, TypeError> {
+                    type_exp(arg, type_env, value_env)
+                })
+                .collect::<Result<Vec<AST>, TypeError>>()?;
+            Ok(AST {
+                node: Exp::Call {
+                    func: function_symbol,
+                    args: typed_args
+                },
+                pos,
+                typ: return_type.clone()
+            })
         }
         _ => panic!("delegation error"),
     }

--- a/src/typecheck/forexp.rs
+++ b/src/typecheck/forexp.rs
@@ -1,24 +1,39 @@
-use crate::ast::*;
-use crate::typecheck::*;
+use super::*;
 
-pub fn typecheck(exp: &Exp, type_env: &TypeEnviroment, value_env:& ValueEnviroment) -> Result<Arc<TigerType>, TypeError> {
-    use TigerType::*;
-    match exp { Exp {node: _Exp::For {var, lo, hi, body, ..}, pos} => {
-        let lo_type = tipo_real(type_exp(&*lo, type_env, value_env)?, type_env);
-        let hi_type = tipo_real(type_exp(&*hi, type_env, value_env)?, type_env);
-        if !es_int(&lo_type) || !es_int(&hi_type) {
-            return Err(TypeError::NonIntegerForRange(*pos));
+pub fn typecheck(
+    AST{node, pos, ..}: AST,
+    type_env: &TypeEnviroment,
+    value_env:& ValueEnviroment
+) -> Result<AST, TypeError> {
+    match node {
+        Exp::For {var, lo, hi, body, escape} => {
+            let lo_ast = type_exp(*lo, type_env, value_env)?;
+            let hi_ast = type_exp(*hi, type_env, value_env)?;
+            let lo_type = tipo_real(lo_ast.typ.clone(), type_env);
+            let hi_type = tipo_real(hi_ast.typ.clone(), type_env);
+            if !es_int(&lo_type) || !es_int(&hi_type) {
+                return Err(TypeError::NonIntegerForRange(pos));
+            }
+            let mut new_value_env = value_env.clone();
+            new_value_env.insert(var.clone(), EnvEntry::Var {
+                ty: Arc::new(TigerType::TInt(R::RO)),
+            });
+            let body_ast = type_exp(*body, type_env, &new_value_env)?;
+            if *body_ast.typ != TigerType::TUnit {
+                return Err(TypeError::NonUnitBody(pos));
+            }
+            Ok(AST {
+                node: Exp::For {
+                    var,
+                    lo: Box::new(lo_ast),
+                    hi: Box::new(hi_ast),
+                    body: Box::new(body_ast),
+                    escape
+                },
+                pos,
+                typ: Arc::new(TigerType::TUnit)
+            })
         }
-        let mut new_value_env = value_env.clone();
-        new_value_env.insert(var.clone(), EnvEntry::Var {
-            ty: Arc::new(TInt(R::RO)),
-        });
-        match *type_exp(&*body, type_env, &new_value_env)? {
-            TUnit => (),
-            _ => return Err(TypeError::NonUnitBody(*pos))
-        };
-        Ok(Arc::new(TUnit))
-    }
-    _ => panic!("delegation panic in forexp::tipar")
+        _ => panic!("delegation panic in forexp::tipar")
     }
 }

--- a/src/typecheck/ifexp.rs
+++ b/src/typecheck/ifexp.rs
@@ -1,29 +1,50 @@
-use crate::ast::*;
-use crate::typecheck::*;
+use super::*;
 
-pub fn typecheck(exp: &Exp, type_env: &TypeEnviroment, value_env: &ValueEnviroment) -> Result<Arc<TigerType>, TypeError> {
-    match exp { Exp {node: _Exp::If{test, then_, else_}, pos} => {
-        if !es_int(&tipo_real(type_exp(&*test, type_env, value_env)?, type_env)) {
-            return Err(TypeError::NonIntegerCondition(*pos));
-        }
-        let then_type = type_exp(&*then_, type_env, value_env)?;
-        match else_ {
-            Some(else_exp) => match type_exp(&*else_exp, type_env, value_env) {
-                Ok(else_type) => if else_type == then_type {
-                    Ok(else_type)
-                }
-                else {
-                    Err(TypeError::ThenElseTypeMismatch(*pos))
-                }
-                Err(type_error) => Err(type_error)
+pub fn typecheck(
+    AST{node, pos, ..}: AST,
+    type_env: &TypeEnviroment,
+    value_env: &ValueEnviroment
+) -> Result<AST, TypeError> {
+    match node {
+        Exp::If{test, then_, else_} => {
+            let test_ast = type_exp(*test, type_env, value_env)?;
+            if !es_int(&tipo_real(test_ast.typ.clone(), type_env)) {
+                return Err(TypeError::NonIntegerCondition(pos));
             }
-            None => if *then_type == TigerType::TUnit {
-                Ok(Arc::new(TigerType::TUnit))
-            } else {
-                Err(TypeError::NonUnitBody(*pos))
+            let then_ast = type_exp(*then_, type_env, value_env)?;
+            match else_ {
+                Some(else_exp) => {
+                    let else_ast = type_exp(*else_exp, type_env, value_env)?;
+                    if else_ast.typ != then_ast.typ {
+                        return Err(TypeError::ThenElseTypeMismatch(pos))
+                    }
+                    let typ = then_ast.typ.clone();
+                    Ok(AST {
+                        node: Exp::If {
+                            test: Box::new(test_ast),
+                            then_: Box::new(then_ast),
+                            else_: Some(Box::new(else_ast)),
+                        },
+                        pos,
+                        typ
+                    })
+                }
+                None => if *then_ast.typ == TigerType::TUnit {
+                    let typ = then_ast.typ.clone();
+                    Ok(AST {
+                        node: Exp::If {
+                            test: Box::new(test_ast),
+                            then_: Box::new(then_ast),
+                            else_: None
+                        },
+                        pos,
+                        typ
+                    })
+                } else {
+                    Err(TypeError::NonUnitBody(pos))
+                }
             }
         }
-    }
         _ => panic!("Delegation error on ifexp::tipar")
     }
 }

--- a/src/typecheck/intexp.rs
+++ b/src/typecheck/intexp.rs
@@ -1,6 +1,8 @@
-use crate::ast::*;
-use crate::typecheck::*;
+use super::*;
 
-pub fn typecheck(_exp: &Exp, _type_env: &TypeEnviroment, _value_env: &ValueEnviroment) -> Result<Arc<TigerType>, TypeError> {
-    Ok(Arc::new(TigerType::TInt(R::RW)))
+pub fn typecheck(AST{node, pos, ..}: AST, _type_env: &TypeEnviroment, _value_env: &ValueEnviroment) -> Result<AST, TypeError> {
+    match &node {
+        Exp::Int(..) => Ok(AST {node, pos, typ: Arc::new(TigerType::TInt(R::RW))}),
+        _ => panic!("delegation error")
+    }
 }

--- a/src/typecheck/mod.rs
+++ b/src/typecheck/mod.rs
@@ -2,8 +2,6 @@
 extern crate uid;
 use std::collections::HashMap;
 pub use std::sync::{Arc, Weak};
-
-
 use crate::ast::*;
 
 mod intexp;
@@ -39,7 +37,8 @@ pub enum TigerType {
     TString,
     TArray(Arc<TigerType>, TypeId),
     TRecord(Vec<(String, Arc<TigerType>, u8)>, TypeId),
-    Internal(String)
+    Internal(String),
+    Untyped,
 }
 
 pub fn tipo_real(t: Arc<TigerType>, tenv: &TypeEnviroment) -> Arc<TigerType> {
@@ -175,25 +174,25 @@ impl PartialEq for TigerType {
     }
 }
 
-pub fn type_exp(exp : &Exp, type_env : &TypeEnviroment, value_env: &ValueEnviroment) -> Result<Arc<TigerType>, TypeError> {
-    match exp {
-        Exp {node, ..} => match node {
-            _Exp::Var(..) => varexp::typecheck(exp, type_env, value_env),
-            _Exp::Unit => unitexp::typecheck(exp, type_env, value_env),
-            _Exp::Nil => nilexp::typecheck(exp, type_env, value_env),
-            _Exp::Int(..) => intexp::typecheck(exp, type_env,&value_env),
-            _Exp::String(..) => stringexp::typecheck(exp, type_env, value_env),
-            _Exp::Call{..} => callexp::typecheck(exp, type_env, value_env),
-            _Exp::Op{..} => opexp::typecheck(exp,&type_env, value_env),
-            _Exp::Assign{..} => assignexp::typecheck(exp, type_env, value_env),
-            _Exp::Record{..} => recordexp::typecheck(exp, type_env, value_env),
-            _Exp::Seq(..) => seqexp::typecheck(exp, type_env, value_env),
-            _Exp::If{..} => ifexp::typecheck(exp, type_env, value_env),
-            _Exp::While{..} => whileexp::typecheck(exp, type_env, value_env),
-            _Exp::For{..} => forexp::typecheck(exp, type_env, value_env),
-            _Exp::Let{..} => letexp::typecheck(exp, type_env, value_env),
-            _Exp::Break => breakexp::typecheck(exp, type_env, value_env),
-            _Exp::Array{..} => arrayexp::typecheck(exp, type_env, value_env),
+pub fn type_exp(ast : AST, type_env : &TypeEnviroment, value_env: &ValueEnviroment) -> Result<AST, TypeError> {
+    match &ast {
+        AST {node, ..} => match node {
+            Exp::Var(..) => varexp::typecheck(ast, type_env, value_env),
+            Exp::Unit => unitexp::typecheck(ast, type_env, value_env),
+            Exp::Nil => nilexp::typecheck(ast, type_env, value_env),
+            Exp::Int(..) => intexp::typecheck(ast, type_env,&value_env),
+            Exp::String(..) => stringexp::typecheck(ast, type_env, value_env),
+            Exp::Call{..} => callexp::typecheck(ast, type_env, value_env),
+            Exp::Op{..} => opexp::typecheck(ast,&type_env, value_env),
+            Exp::Assign{..} => assignexp::typecheck(ast, type_env, value_env),
+            Exp::Record{..} => recordexp::typecheck(ast, type_env, value_env),
+            Exp::Seq(..) => seqexp::typecheck(ast, type_env, value_env),
+            Exp::If{..} => ifexp::typecheck(ast, type_env, value_env),
+            Exp::While{..} => whileexp::typecheck(ast, type_env, value_env),
+            Exp::For{..} => forexp::typecheck(ast, type_env, value_env),
+            Exp::Let{..} => letexp::typecheck(ast, type_env, value_env),
+            Exp::Break => breakexp::typecheck(ast, type_env, value_env),
+            Exp::Array{..} => arrayexp::typecheck(ast, type_env, value_env),
         }
     }
 }

--- a/src/typecheck/nilexp.rs
+++ b/src/typecheck/nilexp.rs
@@ -1,6 +1,8 @@
-use crate::ast::*;
-use crate::typecheck::*;
+use super::*;
 
-pub fn typecheck(_exp: &Exp, _type_env: &TypeEnviroment, _value_env: &ValueEnviroment) -> Result<Arc<TigerType>, TypeError> {
-    Ok(Arc::new(TigerType::TNil))
+pub fn typecheck(AST{node, pos, ..}: AST, _type_env: &TypeEnviroment, _value_env: &ValueEnviroment) -> Result<AST, TypeError> {
+    match &node {
+        Exp::Nil => Ok(AST {node, pos, typ: Arc::new(TigerType::TNil)}),
+        _ => panic!("delegation error")
+    }
 }

--- a/src/typecheck/opexp.rs
+++ b/src/typecheck/opexp.rs
@@ -1,34 +1,49 @@
-use crate::ast::*;
-use crate::typecheck::*;
+use super::*;
 
-pub fn typecheck(exp: &Exp, type_env: &TypeEnviroment, value_env: &ValueEnviroment) -> Result<Arc<TigerType>, TypeError> {
-    match exp { Exp {node: _Exp::Op{left, right, oper}, pos} => {
-        let left_type = tipo_real(type_exp(&*left, type_env, value_env)?, type_env);
-        let right_type = tipo_real(type_exp(&*right, type_env, value_env)?, type_env);
-        match oper {
-            Oper::EqOp | Oper::NeqOp => {
-                if left_type == right_type && *left_type != TigerType::TNil && *right_type != TigerType::TNil {
-                    Ok(Arc::new(TigerType::TInt(R::RW)))
-                } else {
-                    Err(TypeError::TypeMismatch(*pos))
-                }
-            },
-            Oper::PlusOp | Oper::MinusOp | Oper::TimesOp | Oper::DivideOp => {
-                if es_int(&left_type) && es_int(&right_type)  {
-                    Ok(Arc::new(TigerType::TInt(R::RW)))
-                } else {
-                    Err(TypeError::TypeMismatch(*pos))
-                }
-            },
-            Oper::LtOp | Oper::LeOp | Oper::GtOp | Oper::GeOp => {
-                if (es_int(&left_type) && es_int(&right_type)) || (*left_type == TigerType::TString && *right_type == TigerType::TString) {
-                    Ok(Arc::new(TigerType::TInt(R::RW)))
-                } else {
-                    Err(TypeError::TypeMismatch(*pos))
+pub fn typecheck(
+    AST{node, pos, ..}: AST,
+    type_env: &TypeEnviroment,
+    value_env: &ValueEnviroment)
+-> Result<AST, TypeError> {
+    match node {
+        Exp::Op{left, right, oper} => {
+            let left_ast = type_exp(*left, type_env, value_env)?;
+            let right_ast = type_exp(*right, type_env, value_env)?;
+            let left_type = tipo_real(left_ast.typ.clone(), type_env);
+            let right_type = tipo_real(right_ast.typ.clone(), type_env);
+            let op_ast = AST {
+                node: Exp::Op {
+                    oper,
+                    left: Box::new(left_ast),
+                    right: Box::new(right_ast),
+                },
+                pos,
+                typ: Arc::new(TigerType::TInt(R::RW))
+            };
+            match oper {
+                Oper::EqOp | Oper::NeqOp => {
+                    if left_type == right_type && *left_type != TigerType::TNil && *right_type != TigerType::TNil {
+                        Ok(op_ast)
+                    } else {
+                        Err(TypeError::TypeMismatch(pos))
+                    }
+                },
+                Oper::PlusOp | Oper::MinusOp | Oper::TimesOp | Oper::DivideOp => {
+                    if es_int(&left_type) && es_int(&right_type)  {
+                        Ok(op_ast)
+                    } else {
+                        Err(TypeError::TypeMismatch(pos))
+                    }
+                },
+                Oper::LtOp | Oper::LeOp | Oper::GtOp | Oper::GeOp => {
+                    if (es_int(&left_type) && es_int(&right_type)) || (*left_type == TigerType::TString && *right_type == TigerType::TString) {
+                        Ok(op_ast)
+                    } else {
+                        Err(TypeError::TypeMismatch(pos))
+                    }
                 }
             }
         }
-    }
-    _ => panic!("delegation errror on opexp::tipar")
+        _ => panic!("delegation errror on opexp::tipar")
     }
 }

--- a/src/typecheck/recordexp.rs
+++ b/src/typecheck/recordexp.rs
@@ -1,40 +1,65 @@
 use crate::ast::*;
 use crate::typecheck::*;
 
-pub fn typecheck(exp: &Exp, type_env: &TypeEnviroment, value_env: &ValueEnviroment) -> Result<Arc<TigerType>, TypeError> {
-    let tipar_fields = |args: &Vec<(Symbol, Box<Exp>)>| -> HashMap<Symbol, Result<Arc<TigerType>, TypeError>> {
-        args.iter().map(|arg| (arg.0.clone(), type_exp(&*arg.1, type_env, value_env))).rev().collect()
+pub fn typecheck(
+    AST{node, pos, ..}: AST,
+    type_env: &TypeEnviroment,
+    value_env: &ValueEnviroment
+) -> Result<AST, TypeError> {
+    let type_fields = |args: Vec<(Symbol, Box<AST>)>| -> Result<HashMap<Symbol, AST>, TypeError> {
+        args
+            .into_iter()
+            .map(|(symbol, ast)| -> Result<(Symbol, AST), TypeError> {
+                Ok((symbol, type_exp(*ast, type_env, value_env)?))
+            })
+            .collect()
+        //args.iter().map(|arg| (arg.0.clone(), type_exp(*arg.1, type_env, value_env))).rev().collect()
     };
-    match exp { Exp {node: _Exp::Record{fields, typ: record_type_string, ..}, pos} => {
-        let mut field_types = tipar_fields(fields);
-
-        let record_type = &*match type_env.get(record_type_string) {
-            Some(tipo) => tipo_real((*tipo).clone(), type_env).clone(),
-            None => return Err(TypeError::UndeclaredType(*pos))
-        };
-        match record_type {
-            TigerType::TRecord(formals, type_id) => {
-                for formal in formals {
-                    match field_types.get(&*formal.0) {
-                        Some(Ok(field_type)) => if *field_type == formal.1 {
-                            field_types.remove(&*formal.0);
-                        }
-                        else {
-                            return Err(TypeError::TypeMismatch(*pos));
+    match node {
+        Exp::Record{fields, typ: record_type_symbol} => {
+            // Type the fields
+            // If the record type is not a record type, error.
+            // If some field doesn't match the formal type, error.
+            // if field <-> formals is a 1:1, error.
+            let mut typed_fields = type_fields(fields)?;
+            let record_type = match type_env.get(&record_type_symbol) {
+                Some(tipo) => tipo_real(tipo.clone(), type_env),
+                None => return Err(TypeError::UndeclaredType(pos))
+            };
+            match &*record_type {
+                TigerType::TRecord(formals, type_id) => {
+                    if typed_fields.len() > formals.len() {
+                        return Err(TypeError::TooManyArguments(pos))
+                    };
+                    if typed_fields.len() < formals.len() {
+                        return Err(TypeError::MissingRecordField(pos))
+                    };
+                    Ok(AST {
+                        node: Exp::Record{
+                            fields: formals
+                                .iter()
+                                .map(|(name, typ, ..)| -> Result<(Symbol, Box<AST>), TypeError> {
+                                    match typed_fields.remove(name) {
+                                        Some(ast) => {
+                                            if *ast.typ == **typ {
+                                                Ok((name.clone(), Box::new(ast)))
+                                            } else {
+                                                Err(TypeError::TypeMismatch(pos))
+                                            }
+                                        }
+                                        None => Err(TypeError::MissingRecordField(pos))
+                                    }
+                                })
+                                .collect::<Result<Vec<(Symbol, Box<AST>)>, TypeError>>()?,
+                            typ: record_type_symbol,
                         },
-                        Some(Err(type_error)) => return Err((*type_error).clone()),
-                        None =>  return Err(TypeError::MissingRecordField(*pos)),
-                    }
-                }
-                if field_types.is_empty() {
-                    Ok(Arc::new(TigerType::TRecord(formals.clone(), *type_id)))
-                } else {
-                    Err(TypeError::TooManyArguments(*pos))
-                }
-            },
-            TigerType::TUnit | TigerType::TNil | TigerType::TInt(..) | TigerType::TString | TigerType::TArray(..) | TigerType::Internal(..) => Err(TypeError::NotRecordType(*pos)),
+                        typ: Arc::new(TigerType::TRecord(formals.clone(), *type_id)),
+                        pos
+                    })
+                },
+                _ => Err(TypeError::NotRecordType(pos)),
+            }
         }
-    }
-    _ => panic!("delegation panic on recordexp::tipar")
+        _ => panic!("delegation panic on recordexp::tipar")
     }
 }

--- a/src/typecheck/seqexp.rs
+++ b/src/typecheck/seqexp.rs
@@ -1,18 +1,24 @@
-use crate::ast::*;
-use crate::typecheck::*;
+use super::*;
 
-pub fn typecheck(exp: &Exp, type_env: &TypeEnviroment, value_env: &ValueEnviroment) -> Result<Arc<TigerType>, TypeError> {
-    use TigerType::*;
-    match exp { Exp {node: _Exp::Seq(exps), ..} => {
-        let mut seq_type : Arc<TigerType> = Arc::new(TUnit);
-        if exps.is_empty() {
-            panic!("empty seqexp");
+pub fn typecheck(
+    AST{node, pos, ..}: AST,
+    type_env: &TypeEnviroment,
+    value_env: &ValueEnviroment)
+-> Result<AST, TypeError> {
+    match node {
+        Exp::Seq(exps) => {
+            assert!(!exps.is_empty());
+            let typed_seq = exps
+                .into_iter()
+                .map(|exp| type_exp(exp, type_env, value_env))
+                .collect::<Result<Vec<AST>, TypeError>>()?;
+            let typ = typed_seq.last().unwrap().typ.clone();
+            Ok(AST {
+                node: Exp::Seq(typed_seq),
+                pos,
+                typ
+            })
         }
-        for exp in exps {
-            seq_type = type_exp(exp, &type_env, value_env)?;
-        }
-        Ok(seq_type)
-    }
-    _ => panic!("delegation panic on seqexp::tipar")
+        _ => panic!("delegation panic on seqexp::tipar")
     }
 }

--- a/src/typecheck/stringexp.rs
+++ b/src/typecheck/stringexp.rs
@@ -1,6 +1,8 @@
-use crate::ast::*;
-use crate::typecheck::*;
+use super::*;
 
-pub fn typecheck(_exp: &Exp, _type_env: &TypeEnviroment, _value_env: &ValueEnviroment) -> Result<Arc<TigerType>, TypeError> {
-    Ok(Arc::new(TigerType::TString))
+pub fn typecheck(AST{node, pos, ..}: AST, _type_env: &TypeEnviroment, _value_env: &ValueEnviroment) -> Result<AST, TypeError> {
+    match &node {
+        Exp::String(..) => Ok(AST {node, pos, typ: Arc::new(TigerType::TString)}),
+        _ => panic!("delegation error")
+    }
 }

--- a/src/typecheck/unitexp.rs
+++ b/src/typecheck/unitexp.rs
@@ -1,6 +1,8 @@
-use crate::ast::*;
-use crate::typecheck::*;
+use super::*;
 
-pub fn typecheck(_exp: &Exp, _type_env: &TypeEnviroment, _value_env: &ValueEnviroment) -> Result<Arc<TigerType>, TypeError> {
-    Ok(Arc::new(TigerType::TUnit))
+pub fn typecheck(AST{node, pos, ..}: AST, _type_env: &TypeEnviroment, _value_env: &ValueEnviroment) -> Result<AST, TypeError> {
+    match &node {
+        Exp::Unit => Ok(AST {node, pos, typ: Arc::new(TigerType::TUnit)}),
+        _ => panic!("delegation error")
+    }
 }

--- a/src/typecheck/varexp.rs
+++ b/src/typecheck/varexp.rs
@@ -1,5 +1,4 @@
-use crate::ast::*;
-use crate::typecheck::*;
+use super::*;
 
 fn field_type(fields: &[(String, Arc<TigerType>, u8)], symbol: &str) -> Option<Arc<TigerType>> {
     for field in fields {
@@ -11,70 +10,98 @@ fn field_type(fields: &[(String, Arc<TigerType>, u8)], symbol: &str) -> Option<A
 }
 
 pub fn typecheck_var(
-    var: &Var,
-    pos: Pos,
+    Var {kind, pos, ..}: Var,
     type_env: &TypeEnviroment,
-    value_env: &ValueEnviroment,
-) -> Result<Arc<TigerType>, TypeError> {
-    match var {
-        Var::Simple(var_symbol) => match value_env.get(var_symbol) {
-            Some(env_entry) => match env_entry {
-                EnvEntry::Var { ty: var_type, .. } => Ok((*var_type).clone()),
-                _ => Err(TypeError::NotSimpleVar(pos)),
-            },
+    value_env: &ValueEnviroment
+) -> Result<Var, TypeError> {
+    match kind {
+        VarKind::Simple(var_symbol) => match value_env.get(&var_symbol) {
+            // A simple var, as in:
+            // a := foo
+            Some(EnvEntry::Var { ty: var_type, .. }) => Ok(Var {
+                kind: VarKind::Simple(var_symbol),
+                typ: var_type.clone(),
+                pos
+            }),
+            Some(..) => Err(TypeError::NotSimpleVar(pos)),
             None => Err(TypeError::UndeclaredSimpleVar(pos)),
         },
-        Var::Subscript(boxed_var, index) => {
-            let subscript_var = boxed_var;
-            match &**subscript_var {
-                Var::Simple(s) => match value_env.get(s) {
-                    Some(env_entry) => match env_entry {
-                        EnvEntry::Var { ty, .. } => match &**ty {
-                            TigerType::TArray(array_of, _) => {
-                                match *type_exp(&*index, type_env, value_env)? {
-                                    TigerType::TInt(_) => Ok((*array_of).clone()),
-                                    _ => Err(TypeError::SubscriptNotInteger(pos)),
-                                }
+        VarKind::Subscript(subscript_var, index) => {
+            // A subscript var, as in:
+            // a := foo[3]
+            // foo must be a simple var and the index an integer
+            match *subscript_var {
+                Var{kind: VarKind::Simple(s), pos, ..} => match value_env.get(&s) {
+                    Some(EnvEntry::Var { ty: array_type, .. }) => match &**array_type {
+                        TigerType::TArray(array_of, _) => {
+                            let index_ast = type_exp(*index, type_env, value_env)?;
+                            match *index_ast.typ {
+                                TigerType::TInt(_) => Ok(Var{
+                                    kind: VarKind::Subscript(
+                                        Box::new(Var{
+                                            kind: VarKind::Simple(s),
+                                            pos,
+                                            typ: array_type.clone()
+                                        }),
+                                        Box::new(index_ast)
+                                    ),
+                                    pos,
+                                    typ: array_of.clone()
+                                }),
+                                _ => Err(TypeError::SubscriptNotInteger(pos)),
                             }
-
-                            _ => Err(TypeError::NotArrayType(pos)),
-                        },
+                        }
                         _ => Err(TypeError::NotArrayType(pos)),
                     },
+                    Some(..) => Err(TypeError::NotArrayType(pos)),
                     None => Err(TypeError::UndeclaredSimpleVar(pos)),
                 },
-                Var::Field(..) | Var::Subscript(..) => Err(TypeError::NotSimpleVar(pos)),
+                Var{kind: VarKind::Field(..), pos, ..}
+                | Var{kind: VarKind::Subscript(..), pos, ..} => Err(TypeError::NotSimpleVar(pos)),
             }
         }
-        Var::Field(subscript_var, field_symbol) => match &**subscript_var {
-            Var::Simple(record_symbol) => match value_env.get(record_symbol) {
-                Some(env_entry) => match env_entry {
-                    EnvEntry::Var { ty, .. } => match &**ty {
-                        TigerType::TRecord(vars, _) => match field_type(vars, &field_symbol) {
-                            Some(field_type) => Ok(field_type),
-                            None => Err(TypeError::FieldDoesNotExist(pos)),
+        VarKind::Field(subscript_var, field_symbol) =>
+            // A field var as in:
+            // a := foo.bar
+            match &*subscript_var {
+                Var{kind: VarKind::Simple(record_symbol), ..} => match value_env.get(record_symbol) {
+                    Some(env_entry) => match env_entry {
+                        EnvEntry::Var { ty, .. } => match &**ty {
+                            TigerType::TRecord(vars, _) => match field_type(vars, &field_symbol) {
+                                Some(field_type) => Ok(Var{
+                                    kind: VarKind::Field(subscript_var, field_symbol),
+                                    typ: field_type,
+                                    pos
+                                }),
+                                None => Err(TypeError::FieldDoesNotExist(pos)),
+                            },
+                            _ => Err(TypeError::NotRecordType(pos)),
                         },
                         _ => Err(TypeError::NotRecordType(pos)),
                     },
-                    _ => Err(TypeError::NotRecordType(pos)),
+                    None => Err(TypeError::UndeclaredSimpleVar(pos)),
                 },
-                None => Err(TypeError::UndeclaredSimpleVar(pos)),
+                Var{kind: VarKind::Field(..), ..} | Var{kind: VarKind::Subscript(..), ..} => Err(TypeError::NotSimpleVar(pos)),
             },
-            Var::Field(..) | Var::Subscript(..) => Err(TypeError::NotSimpleVar(pos)),
-        },
     }
 }
 
 pub fn typecheck(
-    exp: &Exp,
+    AST{node, pos, ..}: AST,
     type_env: &TypeEnviroment,
     value_env: &ValueEnviroment,
-) -> Result<Arc<TigerType>, TypeError> {
-    match exp {
-        Exp {
-            node: _Exp::Var(var),
-            pos,
-        } => typecheck_var(var, *pos, type_env, value_env),
+) -> Result<AST, TypeError> {
+    // A Var literal
+    match node {
+        Exp::Var(var) => {
+            let typed_var = typecheck_var(var, type_env, value_env)?;
+            let typ = typed_var.typ.clone();
+            Ok(AST {
+                node: Exp::Var(typed_var),
+                pos,
+                typ
+            })
+        },
         _ => panic!("le llego algo nada que ver a varexp::tipar"),
     }
 }

--- a/src/typecheck/whileexp.rs
+++ b/src/typecheck/whileexp.rs
@@ -1,14 +1,27 @@
-use crate::ast::*;
-use crate::typecheck::*;
+use super::*;
 
-pub fn typecheck(exp: &Exp, type_env: &TypeEnviroment, value_env: &ValueEnviroment) -> Result<Arc<TigerType>, TypeError> {
-    match exp { Exp {node: _Exp::While {test, body}, pos} =>{
-            if !es_int(&tipo_real(type_exp(&*test, type_env, value_env)?, type_env)) {
-                return Err(TypeError::NonIntegerCondition(*pos));
+pub fn typecheck(
+    AST{node, pos, ..}: AST,
+    type_env: &TypeEnviroment,
+    value_env: &ValueEnviroment
+) -> Result<AST, TypeError> {
+    match node {
+        Exp::While {test, body} => {
+            let test_ast = type_exp(*test, type_env, value_env)?;
+            if !es_int(&tipo_real(test_ast.typ.clone(), type_env)) {
+                return Err(TypeError::NonIntegerCondition(pos));
             }
-            match *type_exp(body, type_env, value_env)? {
-                TigerType::TUnit => Ok(Arc::new(TigerType::TUnit)),
-                _ => Err(TypeError::NonUnitBody(*pos))
+            let body_ast = type_exp(*body, type_env, value_env)?;
+            match *body_ast.typ {
+                TigerType::TUnit => Ok(AST {
+                    node: Exp::While{
+                        test: Box::new(test_ast),
+                        body: Box::new(body_ast)
+                    },
+                    typ: Arc::new(TigerType::TUnit),
+                    pos
+                }),
+                _ => Err(TypeError::NonUnitBody(pos))
             }
         }
         _ => panic!("le llego cualquier cosa a whileexp::tipar")


### PR DESCRIPTION
- Redefined ASTs to include a type property
- Rewrited all typechecking functions to rebuild the AST, now moved into
them.
- Renamed Exp and _Exp. Those were temporaty names.
- Fixed tests and escape calculation accordingly.